### PR TITLE
Add Week 3 blog post: How to Budget a Home Renovation (#30)

### DIFF
--- a/src/content/blog/how-to-budget-a-home-renovation.md
+++ b/src/content/blog/how-to-budget-a-home-renovation.md
@@ -1,0 +1,168 @@
+---
+title: "How to Budget a Home Renovation Without Going Over (2026)"
+description: "How to budget a home renovation without going over: a step-by-step 2026 method using real quotes, the right contingency, and tracking that survives the build."
+lede: "To budget a home renovation without going over, build it from itemised quotes (not a single lump sum), add a 15–25% contingency, and track actual vs. estimated per line item from day one. The overrun almost always comes from costs nobody listed, not from prices that rose."
+keyword: "how to budget a home renovation"
+publishDate: 2026-05-29
+author: "Robert Jensen"
+tags: ["budgeting", "planning", "how-to"]
+tldr:
+  - "Budget from <strong>itemised contractor quotes</strong>, not a single lump-sum guess — overruns hide in the lines you forgot to list."
+  - "Add a <strong>contingency of 15–25%</strong> depending on the home's age and condition, and ring-fence it so it isn't spent early."
+  - "Include the <strong>hidden third</strong>: permits, design fees, finance costs, disposal, temporary living, and the cost of finishing (furniture, decoration)."
+  - "Track <strong>actual vs. estimated per line item</strong> — not per room — or you lose sight of where the money is leaking."
+  - "Spreadsheets work for planning; for on-site tracking, an app like <a href='https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960'>Home Stories</a> keeps the numbers current without nightly admin."
+faq:
+  - question: "How much should I budget for a home renovation?"
+    answer: "Don't start from a price-per-square-metre figure — finishes, region, and scope vary too much for it to mean anything. Instead, get three itemised quotes for each major trade, sum them, then add the hidden third (permits, design, finance, disposal, fixtures, decoration) and a 15–25% contingency on top. For DIY work, multiply your material list by 1.3 to cover waste and forgotten items."
+  - question: "How do I stop a renovation from going over budget?"
+    answer: "The two biggest levers are scope discipline and live tracking. Lock the scope before work starts and treat every change as a written change order with its own cost. Then track actual spend against your estimate per line item, every week — overruns caught early can be offset elsewhere; overruns found at the end can't. A budget you don't update is a wish, not a budget."
+  - question: "What percentage should I add for contingency?"
+    answer: "20% for homes built before 1990 (more surprises behind the walls), 15% for newer homes in good condition, and 25% if there are known structural issues or you're opening up unknown areas. Ring-fence the contingency in its own line so it's psychologically separate from the working budget — otherwise it gets quietly spent on upgrades by week three."
+  - question: "What costs do people forget in a renovation budget?"
+    answer: "The usual missing lines are permits and inspection fees, design and architect fees, structural/engineering reports, demolition and skip/disposal costs, finance and loan interest, temporary accommodation or storage, appliances and fixtures (often quoted as 'supply by client'), and the finishing layer — paint, flooring trims, blinds, and furniture. Together these routinely add 30–50% on top of the construction quote."
+  - question: "Should I budget per room or per trade?"
+    answer: "Both, but track per line item. Plan the scope room by room (it's how you think about the house), but build the budget around trades and cost categories (demolition, structural, plumbing, electrical, finishes) because that's how quotes and invoices arrive. The line item is the unit that lets you see exactly where an overrun started."
+  - question: "How often should I update my renovation budget?"
+    answer: "Weekly at minimum, ideally at the moment each cost is committed. The danger isn't a single big surprise — it's small drift you don't notice because you're updating the budget a fortnight late. Logging each receipt and change as it happens is the single habit that keeps a renovation on budget."
+relatedSlugs:
+  - "renovation-budget-template"
+  - "renovation-spreadsheet-alternative"
+---
+
+Most renovations don't blow the budget because prices rose 40% overnight. They blow it because the budget was never complete in the first place — and because nobody tracked it once the dust started flying. Fix those two things and you've fixed 90% of overruns.
+
+This is the method I've used across my own projects and watched work for friends: build the number from the ground up, protect it with the right contingency, and keep it alive while the work happens. It takes a couple of hours to set up and about five minutes a week to maintain.
+
+![A homeowner sitting at a kitchen table in a half-renovated kitchen, reviewing an invoice with a spread of paper receipts and a phone in front of him](/stock/03.webp)
+
+## Step 1: Define the scope before you touch a number
+
+A budget is downstream of scope. If the scope is vague — "do up the kitchen" — the budget will be a guess, and guesses go over.
+
+Before you cost anything, write down, room by room, exactly what's changing:
+
+- **Structural?** Moving walls, removing chimney breasts, steel beams, new openings.
+- **Layout?** New plumbing or electrical runs, which are far more expensive than working with what's there.
+- **Surfaces?** Floors, walls, ceilings — and to what standard.
+- **Fixtures and fittings?** Kitchen units, sanitaryware, lighting, ironmongery.
+- **The finish level.** "Landlord neutral" and "forever home" can differ by 3× on the same floor area.
+
+The single most useful sentence you can write is a **scope freeze**: the point after which any change becomes a documented, costed change order rather than a casual "while you're at it." Scope creep is the quiet killer — five "small" additions at $1,500 each is $7,500 you never planned for.
+
+## Step 2: Build the budget from itemised quotes, not a lump sum
+
+Here's the mistake that sinks most budgets: writing one line that says *"Kitchen — $25,000"* and treating it as fact.
+
+That number is useless the moment you're standing in a tile shop deciding between porcelain and ceramic, because you have no idea how much of the $25k is already spoken for. A real budget is built from **line items**, grouped into categories. The nine categories I use on every project:
+
+1. **Design & permits** — architect, drawings, planning/building permits, structural reports.
+2. **Demolition & disposal** — strip-out labour, skips, tip fees.
+3. **Structural** — beams, foundations, walls, openings.
+4. **MEP** — mechanical, electrical, plumbing (the expensive hidden trades).
+5. **Finishes** — plaster, flooring, tiling, paint.
+6. **Fixtures** — kitchen, bathroom, lighting, built-ins.
+7. **Furniture & decoration** — the layer that makes it feel finished.
+8. **Finance** — loan interest, arrangement fees, the cost of the money itself.
+9. **Contingency** — covered in Step 4.
+
+For each major trade, **get three itemised quotes**. Not "ballpark over the phone" — written, broken-down quotes you can compare line by line. Three quotes does two things: it gives you a realistic market price, and it shows you what one contractor included that another quietly left out (the "supply by client" trap on appliances and tiles is the classic).
+
+If you're doing parts yourself, price the material list in full and **multiply by 1.3** — waste, offcuts, the second trip to the merchant, and the thing you forgot are real and predictable.
+
+> A useful sanity check: the construction quote is usually only 60–70% of the true project cost. If your budget *is* the quote, you're already 30–50% short.
+
+## Step 3: Add the hidden third
+
+This is where complete budgets separate from optimistic ones. Beyond the building work itself, these costs are almost universal and almost universally forgotten:
+
+| Often-missed cost | Why it bites |
+|---|---|
+| Permits & inspection fees | Required, non-negotiable, easy to forget at planning stage |
+| Design & engineering fees | Architect/structural fees can be 5–12% of build cost |
+| Demolition & disposal | Skips and tip fees add up fast on a strip-out |
+| Finance costs | Loan interest and fees during a months-long project |
+| Temporary living / storage | If the kitchen or bathroom is out of action |
+| Appliances & fixtures | Frequently excluded from contractor quotes |
+| The finishing layer | Paint, trims, blinds, handles, furniture |
+| Snagging & defects | The final 5% always costs more attention than expected |
+
+The U.S. Federal Trade Commission's [guidance on hiring a contractor](https://consumer.ftc.gov/articles/hiring-contractor) makes the same point from the consumer-protection angle: get everything — payment schedule, what's included, what isn't — in writing before work starts. A vague quote is a budget overrun waiting to happen.
+
+Add these lines explicitly. A budget that lists them is honest; one that doesn't just delays the bad news.
+
+## Step 4: Set the right contingency — and ring-fence it
+
+Contingency isn't padding or pessimism. It's a line item for the surprises you can't see yet — the rot behind the bath, the wiring that doesn't meet code, the floor that isn't level.
+
+My rule of thumb:
+
+- **15%** — newer home (post-1990), good condition, nothing being opened up.
+- **20%** — older home, or any project disturbing walls/floors/services.
+- **25%** — pre-war home, known structural issues, or large unknowns.
+
+Two things make contingency actually work:
+
+1. **Ring-fence it.** Keep it as its own line, mentally and on paper. The failure mode is spending it on upgrades in week three ("the contingency's there, let's get the nicer worktop") and then having nothing left when the real surprise arrives in week eight.
+2. **Draw it down visibly.** Each time you dip in, log what for. A contingency that quietly empties teaches you nothing; one you track tells you exactly how accurate your original estimates were.
+
+There's a deeper dive on this coming in a dedicated contingency post, but the headline is simple: budget the surprise *before* it happens, and protect it once you have.
+
+## Step 5: Track actual vs. estimated — per line item
+
+You can do everything above perfectly and still go over, because **a budget you don't update is just a hopeful spreadsheet.** The control happens during the build, not before it.
+
+The rule: track **actual spend against your estimate, per line item, every week.** Per line item — not per room, not per category — because that's the only resolution fine enough to show you *where* a number started slipping.
+
+Home Stories tracks actual vs. estimated per line and shows the running total against your budget — so you can log a receipt at the merchant in ten seconds and see instantly whether you're still on plan. [It's free on the App Store](https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960).
+
+Why weekly, and why per line:
+
+- **Caught early, an overrun is recoverable.** If tiling comes in $600 over in week four, you have eleven weeks to trim elsewhere. Found at handover, it's just a hole.
+- **Drift is invisible at category level.** "Finishes" looking fine can hide flooring being 30% over and paint being 30% under. The line item shows the truth.
+- **Late logging loses information.** Log "builder's merchant — approx $340" a fortnight later and you've lost the line-item detail that made the budget useful in the first place. This is exactly [where spreadsheets break down on site](/blog/renovation-spreadsheet-alternative/).
+
+## Step 6: Manage change orders like a contractor would
+
+Once work starts, every "while you're at it" is a budget event. Treat it like one:
+
+1. Write down what's changing and why.
+2. Get the cost in writing before saying yes.
+3. Decide where it comes from — new money, or a trade-off against another line.
+4. Update the budget the same day.
+
+That four-step habit is what separates a renovation that lands near plan from one that drifts $10,000 over through a dozen unrecorded yeses.
+
+## A worked example
+
+Say your kitchen-and-bathroom project has construction quotes totalling **$40,000**. A complete budget looks more like:
+
+| Category | Estimate |
+|---|---|
+| Construction (from quotes) | $40,000 |
+| Design & permits | $3,500 |
+| Demolition & disposal | $2,000 |
+| Appliances & fixtures (client supply) | $6,000 |
+| Finishing layer (paint, trims, blinds) | $2,500 |
+| Finance costs | $1,500 |
+| Temporary kitchen / eating out | $1,000 |
+| **Subtotal** | **$56,500** |
+| Contingency (20%) | $11,300 |
+| **Total budget** | **$67,800** |
+
+The $40,000 quote was real — but the true number to plan and finance around is nearly **$68,000**. People who budgeted $40k didn't overspend by 70%; they under-budgeted by the hidden third and the contingency from the start.
+
+## Putting it together
+
+Budgeting a renovation without going over isn't about predicting the future perfectly. It's about:
+
+1. **Freezing the scope** so the number has something solid to attach to.
+2. **Building from itemised quotes**, not a lump sum.
+3. **Adding the hidden third** — the costs everyone forgets.
+4. **Ring-fencing a real contingency** sized to the home.
+5. **Tracking actual vs. estimated per line, weekly.**
+6. **Treating every change as a costed change order.**
+
+Steps 1–4 happen at a desk and a [budget template](/blog/renovation-budget-template/) is perfect for them. Steps 5–6 happen on-site, one-handed, in the dust — which is exactly where a desk tool stops working and a phone-first tracker takes over.
+
+If you want the live-tracking half handled for you, [Home Stories is free on the App Store](https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960), built specifically to keep a renovation budget current without nightly admin. Set up your categories once, log as you go, and always know — to the line item — exactly where you stand.


### PR DESCRIPTION
## Summary

Adds the **Week 3** blog post from the content calendar in #30.

- **Title:** How to Budget a Home Renovation Without Going Over (2026)
- **Keyword:** `how to budget a home renovation`
- **Type:** How-to, ~2,300 words

## Structure & SEO
- Standard skeleton: H1 → snippet-ready lede → TL;DR → 6-step body → mid-CTA → FAQ (6 Q, FAQPage schema) → related → end-CTA
- Keyword in slug, H1, first 100 words, and an H2
- In-content visual (`/stock/03.webp`) with descriptive alt text
- Internal links to Week 1 (budget template) and Week 2 (spreadsheet alternative); `relatedSlugs` set
- External authoritative link (FTC "hiring a contractor" guidance)
- Auto-generated 1200×630 OG image + RSS entry

## Verification
- `pnpm build` succeeds — post page, OG image, and RSS entry all generated
- Rendered and screenshot-checked in browser preview (title, lede, TL;DR, image, tables, FAQ, CTAs all render)

Refs #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)