### PR TITLE
Add Week 6 blog post: Renovation Contingency Budget (#30)

### DIFF
--- a/src/content/blog/how-to-budget-a-home-renovation.md
+++ b/src/content/blog/how-to-budget-a-home-renovation.md
@@ -26,6 +26,7 @@ faq:
   - question: "How often should I update my renovation budget?"
     answer: "Weekly at minimum, ideally at the moment each cost is committed. The danger isn't a single big surprise — it's small drift you don't notice because you're updating the budget a fortnight late. Logging each receipt and change as it happens is the single habit that keeps a renovation on budget."
 relatedSlugs:
+  - "renovation-contingency-budget"
   - "renovation-budget-template"
   - "renovation-spreadsheet-alternative"
 ---
@@ -106,7 +107,7 @@ Two things make contingency actually work:
 1. **Ring-fence it.** Keep it as its own line, mentally and on paper. The failure mode is spending it on upgrades in week three ("the contingency's there, let's get the nicer worktop") and then having nothing left when the real surprise arrives in week eight.
 2. **Draw it down visibly.** Each time you dip in, log what for. A contingency that quietly empties teaches you nothing; one you track tells you exactly how accurate your original estimates were.
 
-There's a deeper dive on this coming in a dedicated contingency post, but the headline is simple: budget the surprise *before* it happens, and protect it once you have.
+There's a deeper dive in the dedicated guide to [how much renovation contingency to set aside](/blog/renovation-contingency-budget/), but the headline is simple: budget the surprise *before* it happens, and protect it once you have.
 
 ## Step 5: Track actual vs. estimated — per line item
 

--- a/src/content/blog/renovation-contingency-budget.md
+++ b/src/content/blog/renovation-contingency-budget.md
@@ -1,0 +1,141 @@
+---
+title: "Renovation Contingency Budget: How Much to Set Aside"
+description: "How big a renovation contingency budget you really need, what it's for, when to dip in, and how to track it so surprises don't sink the project."
+lede: "A renovation contingency budget isn't padding or pessimism — it's a funded line item for the surprises you can't see yet. Size it to the home (15–25%, not the builder's-folklore 10%), ring-fence it so it isn't spent on upgrades by week three, and draw it down visibly so you always know how much runway is left."
+keyword: "renovation contingency budget"
+publishDate: 2026-06-15
+author: "Robert Jensen"
+tags: ["budgeting", "planning", "how-to"]
+tldr:
+  - "Set the contingency by the home's <strong>age and condition</strong>: ~15% for newer homes, 20% for anything pre-1990 or where walls are opened up, 25%+ for known structural unknowns. The 10% figure is borrowed from new-build and is too low for renovations."
+  - "Contingency covers <strong>genuine surprises</strong> — rot, non-compliant wiring, an un-level floor — not scope upgrades you talked yourself into. Keep the two strictly separate."
+  - "<strong>Ring-fence it</strong> as its own line and resist spending it early. The classic failure is dipping in for a nicer worktop in week three and having nothing left for the real surprise in week eight."
+  - "<strong>Draw it down visibly.</strong> Log every dip — what for, how much, what's left — so the remaining buffer is always a number you can see, not a vibe."
+  - "Spreadsheets are fine for setting the contingency; for watching it drain in real time on-site, an app like <a href='https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960'>Home Stories</a> keeps the running balance current without nightly admin."
+faq:
+  - question: "How much contingency should I budget for a renovation?"
+    answer: "Size it to the home, not to a flat rule. Use about 15% for a newer home (post-1990) in good condition with nothing being opened up, 20% for an older home or any project disturbing walls, floors, or services, and 25% or more for a pre-war home, known structural issues, or large unknown areas. The common 10% figure comes from new construction, where the site is a blank slab — renovations have far more hidden risk, so 10% almost always runs out."
+  - question: "Is contingency calculated on the construction cost or the whole budget?"
+    answer: "Calculate it on your complete pre-contingency budget — construction plus the hidden third (permits, design fees, finance, disposal, fixtures, finishing). Applying the percentage only to the contractor's quote understates the buffer, because overruns happen across every category, not just the build itself. Sum every other line, then add the contingency percentage on top of that subtotal."
+  - question: "What is a renovation contingency actually for?"
+    answer: "It's for genuine surprises that no reasonable plan could have priced: rot or water damage behind a wall, wiring or plumbing that doesn't meet current code, a floor that isn't level, a wall that turns out to be load-bearing, or a drain that runs the opposite way to the plans. It is not for upgrades, scope additions, or 'while we're at it' choices — those are change orders and should come from new money or a trade-off against another line."
+  - question: "When is it okay to dip into the contingency?"
+    answer: "When the cost is a true surprise (couldn't have been foreseen or quoted), it's necessary (the project can't proceed correctly without it), and you log the draw immediately — what it was for, how much, and how much remains. If it fails any of those tests, it's probably scope creep dressed up as a surprise, and it should be a conscious change-order decision instead of a quiet raid on the buffer."
+  - question: "What if I don't use all my contingency?"
+    answer: "That's the goal, not a waste. Unspent contingency is money returned to you at the end of the project, or a buffer you can consciously redeploy in the final stages — for example into the finishing layer — once the high-risk phases (demolition, structural, first-fix) are behind you and the remaining unknowns are small. The mistake is treating a healthy buffer in week three as 'spare' and spending it before the risky work has even started."
+  - question: "How do I keep track of contingency during the build?"
+    answer: "Treat it as a live balance, not a fixed number. Start with the funded amount, and every time you draw on it, subtract the amount and note the reason, so the remaining buffer is always visible. Watch the trend, not just the total: contingency dropping fast in the first few weeks is an early warning that your estimates were optimistic and the scope may need cutting. Logging each draw as it happens — ideally in something you can update on-site — is what turns contingency from a guess into a control."
+relatedSlugs:
+  - "how-to-budget-a-home-renovation"
+  - "renovation-budget-template"
+  - "home-renovation-phases"
+---
+
+Almost every renovation that goes over budget had a contingency — on paper. The problem is rarely that homeowners forget the line entirely. It's that they size it too small, spend it on the wrong things, and never actually watch it drain until it's already gone. By then "contingency" has quietly become "the money we spent on the upgrades we couldn't resist," and there's nothing left for the wall that turns out to be holding the house up.
+
+This post is the dedicated deep-dive promised in [how to budget a home renovation](/blog/how-to-budget-a-home-renovation/): how much contingency to set aside, what it's genuinely for, when it's fair to dip in, and how to keep it honest while the dust is flying.
+
+![A renovator sitting on the bare concrete floor of a half-finished room, surrounded by flooring and tile samples, checking figures on his phone](/stock/02.webp)
+
+## What a contingency actually is (and isn't)
+
+A renovation contingency is a **funded line item for the surprises you can't see yet.** It is not optimism, padding, or a vague "we'll figure it out." It's real money, set aside on purpose, for the specific category of cost that no honest quote could have predicted.
+
+The distinction that matters most — and the one that breaks budgets when it blurs — is **surprise versus upgrade.**
+
+- A **surprise** is the rot behind the bath, the wiring that doesn't meet code, the joist with woodworm, the floor that's 30mm out of level, the "stud wall" that turns out to be load-bearing. Nobody could have quoted these without opening the wall.
+- An **upgrade** is the nicer worktop, the underfloor heating you decided you wanted, the extra downlights, the "while we're in here, let's also…". These are choices, not surprises.
+
+Contingency covers the first list. It must never quietly fund the second. The moment an upgrade gets paid for out of contingency, you've spent your insurance against the unknown on something you chose — and the unknown still arrives, on schedule, with an empty buffer waiting for it.
+
+## How much: size it to the home, not to folklore
+
+There's a persistent rule of thumb that 10% contingency is enough. **For renovations, it isn't.** That number is borrowed from new construction, where you're building on a blank slab with relatively few unknowns. A renovation is the opposite: the unknowns *are the entire reason renovations cost more than people expect.*
+
+My rule of thumb, sized to the risk that's actually behind the walls:
+
+| Home & project | Contingency |
+|---|---|
+| Newer home (post-1990), good condition, surfaces only | 15% |
+| Older home, or any project opening up walls/floors/services | 20% |
+| Pre-war home, known structural issues, large unknown areas | 25%+ |
+
+These percentages look high to people anchored on 10%. They are roughly the percentages by which the average renovation *goes over* when contingency is set too low — which is not a coincidence. The overrun and the missing contingency are the same number viewed from opposite ends.
+
+**Calculate it on the whole budget, not just the build.** Add up every other line first — construction, plus the "hidden third" of permits, design fees, finance, disposal, fixtures, and the finishing layer — then apply the contingency percentage to that subtotal. Applying it only to the contractor's quote is the most common way people end up under-buffered, because overruns don't politely confine themselves to the construction line.
+
+A quick worked example, carrying on from a project with a pre-contingency subtotal of **$56,500**:
+
+| Line | Amount |
+|---|---|
+| Pre-contingency subtotal | $56,500 |
+| Contingency at 20% | $11,300 |
+| **Total budget** | **$67,800** |
+
+That $11,300 isn't slack you hope not to use loosely. It's a specific bet that, on a project of this size and age, somewhere between zero and eleven-and-a-bit thousand dollars of genuine surprises are waiting. You're funding the bet up front so it doesn't become a panic later.
+
+## Ring-fence it: the week-three trap
+
+Setting the right number is the easy half. The hard half is not spending it before you need it.
+
+Here's the failure mode, and it's almost universal: the demolition goes smoothly, the first-fix looks fine, and three weeks in you're feeling good. You're choosing worktops, and the upgrade from laminate to quartz is "only" $1,400. *The contingency's right there, and we're under so far — let's just do it.* Multiply that decision by the kitchen, the bathroom, the lighting, and the flooring, and by week six the buffer is gone. Then in week eight the plumber opens a wall and finds the soil stack needs replacing, and there's no money for the one thing contingency actually existed to cover.
+
+Two habits prevent this:
+
+1. **Keep it as its own line, mentally and on paper.** It is not part of the working budget. It does not show up as "available." If you're choosing an upgrade, the money comes from new money or from trading down another line — never from contingency.
+2. **Apply a simple test before every draw.** Is it a genuine *surprise* (couldn't have been foreseen)? Is it *necessary* (the project can't proceed correctly without it)? Did you *log it immediately*? If it fails any of the three, it's scope creep wearing a disguise, and it deserves a conscious change-order decision instead of a quiet raid. (More on handling those in [the budgeting guide's change-order section](/blog/how-to-budget-a-home-renovation/).)
+
+## Draw it down visibly
+
+Even a well-sized, ring-fenced contingency fails if you can't see it. A buffer you don't track isn't a control — it's a feeling, and feelings are reliably more optimistic than the receipts.
+
+Treat contingency as a **live balance**, exactly like the balance on a bank account:
+
+- Start with the funded amount ($11,300 in the example).
+- Every time you draw on it, subtract the amount and note *what for* (e.g. "−$2,100, soil stack replacement, week 8").
+- The remaining figure is always a number you can read at a glance, not a guess.
+
+And watch the **trend, not just the total.** Contingency draining fast in the first few weeks is one of the most valuable early-warning signals a renovation gives you: it means your original estimates were optimistic, the surprises are stacking up, and you should be cutting scope *now*, while you still have time to react — not at handover, when the only options are a bigger loan or an unfinished room.
+
+This is precisely the kind of running balance a spreadsheet handles fine at the desk and badly on-site. Home Stories keeps the contingency as a live line alongside the rest of the budget, so when you log a surprise cost at the builder's merchant, the remaining buffer updates instantly and you can see — to the dollar — how much runway is left. [It's free on the App Store](https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960).
+
+## When it's actually fair to dip in
+
+Putting the surprise-versus-upgrade test into practice, here's the difference in real situations:
+
+**Fair draws on contingency:**
+
+- The electrician finds the existing wiring isn't to code and legally must be replaced.
+- Demolition reveals water damage and rot in a structural timber.
+- A "stud" wall is load-bearing and needs a beam to remove safely.
+- The floor is so far out of level that the new flooring can't be laid without it.
+
+**Not contingency — these are change orders:**
+
+- You decide you'd prefer the more expensive tiles after all.
+- You add a feature that wasn't in the original scope ("let's also do the hallway").
+- A trade quoted low and you simply want a better finish than budgeted.
+- You forgot to budget a known cost — that's a planning gap to correct, not a surprise.
+
+The honest question to ask at the moment of decision is: *"If I'd had a crystal ball before the work started, would this cost have been on the plan?"* If yes, it was foreseeable and belongs in the main budget. If genuinely no — it was hidden behind a wall or under a floor — that's what the contingency is for.
+
+## What if you don't spend it all?
+
+Then you've done it right. Unspent contingency is not waste; it's money handed back to you at the end, or a buffer you can **consciously** redeploy once the high-risk phases are behind you.
+
+The sequencing matters. The riskiest moments in a renovation are demolition, structural work, and first-fix — the phases where walls and floors are open and surprises surface. (The [seven phases post](/blog/home-renovation-phases/) walks through where each risk lives.) Once those are done and the remaining unknowns are small, a healthy contingency balance is genuinely earned slack. *That's* the right moment to decide, deliberately, to move some of it into the finishing layer — not week three, when the risky work hasn't even started and every dollar of buffer is still doing a job.
+
+So the rule is simply about timing: don't treat the buffer as spare until the surprises it insures against can no longer happen.
+
+## Putting it together
+
+A renovation contingency budget that actually protects you comes down to four things:
+
+1. **Size it to the home** — 15% / 20% / 25%+ by age and how much you're opening up, calculated on the whole pre-contingency budget, not just the build.
+2. **Keep it strictly for surprises** — rot, code, structure, level — and never for upgrades.
+3. **Ring-fence it** so it survives the week-three temptation to spend it early.
+4. **Draw it down visibly** and watch the trend, so a fast-draining buffer warns you in time to cut scope.
+
+The setup happens at a desk, and a [budget template](/blog/renovation-budget-template/) handles it well. The hard part — keeping the buffer honest while you're standing in a half-demolished room logging a surprise cost one-handed — happens on-site, which is exactly where a desk tool stops working.
+
+If you'd rather have the live balance handled for you, [Home Stories is free on the App Store](https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960). Set your contingency once, log each draw as it happens, and always know — to the line item — how much of your buffer is left to face whatever's behind the next wall.


### PR DESCRIPTION
## Summary
New Week 6 blog post in the renovation series: **Renovation Contingency Budget: How Much to Set Aside** → `/blog/renovation-contingency-budget/`.

Covers the dedicated contingency deep-dive that was teased in the *How to Budget* post:
- How much to set aside, sized to the home (15% / 20% / 25%+ by age and how much is opened up) — and why the folklore 10% is too low
- The surprise-vs-upgrade distinction (what contingency is and isn't for)
- Ring-fencing it against the "week-three" temptation to spend it on upgrades
- Drawing it down visibly as a live balance, and watching the trend as an early warning
- When it's fair to dip in, and what to do with the unspent buffer

## Details
- Matches existing house style: bold lede, 5-bullet TL;DR (closing App Store link), 6 FAQ items, 2 tables, cover image (`/stock/02.webp`), mid + closing App Store CTAs, `relatedSlugs` to the budget/template/phases posts
- `publishDate: 2026-06-15` (next in the weekly cadence after Week 5)
- Turned the "dedicated contingency post coming" teaser in `how-to-budget-a-home-renovation.md` into a real link and added the new slug to its related list

## Verification
- Docker production build passes (content schema validates, all 12 pages + `/rss.xml` generated)
- Browser-tested locally: post + index return 200, no console errors; lede, TL;DR, image, tables, FAQ, related posts, internal link, and App Store CTA all render; new card appears at the top of `/blog/`

Part of #30 (Blog content launch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Knaj5x49L9DannL1BT3eKo