### PR TITLE
Add Week 8 blog post: Notion vs Home Stories for Renovation Planning (#30)

### DIFF
--- a/src/content/blog/notion-for-home-renovation.md
+++ b/src/content/blog/notion-for-home-renovation.md
@@ -1,0 +1,117 @@
+---
+title: "Notion vs Home Stories for Renovation Planning"
+description: "Notion is a brilliant renovation planning tool and a frustrating on-site one. Here's exactly where each fits — and why most people end up needing both."
+lede: "Notion is genuinely excellent for the planning half of a renovation: research, mood boards, contractor notes, a flexible database you can shape however you think. It's just as genuinely frustrating for the execution half — logging a receipt one-handed in a dusty kitchen — because it was never built for a phone on a building site. This is an honest map of where each tool wins."
+keyword: "notion for home renovation"
+publishDate: 2026-06-22
+author: "Robert Jensen"
+tags: ["planning", "tools", "comparison"]
+tldr:
+  - "<strong>Notion wins the planning phase.</strong> Free-form pages, databases, mood boards, contractor research, and document storage — it's one of the best tools there is for thinking a renovation through before work starts."
+  - "<strong>Home Stories wins the execution phase.</strong> It's a phone-first <a href='https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960'>renovation tracker</a> built for one-handed logging on-site: a cost, a photo, a task, updated in seconds while you're standing in the room."
+  - "The deciding factor isn't features — it's <strong>where and how you log</strong>. Notion assumes a desk and focus; a live renovation gives you neither."
+  - "The honest answer for most people is <strong>both</strong>: Notion for the static planning artefacts, a phone-first app for the live running balance once the dust starts flying."
+  - "If you only want one tool for the part that actually breaks — keeping the budget honest while work is underway — that's the part Notion handles worst and Home Stories was built for."
+faq:
+  - question: "Is Notion good for planning a home renovation?"
+    answer: "Yes — for planning, it's one of the best tools available. Notion's flexible pages and databases let you build a renovation hub exactly how you think: room-by-room pages, a contractor database, mood boards, quote comparisons, and document storage all in one place. Where it struggles is execution — logging costs, photos, and progress from your phone while you're on-site — because it's fundamentally a desk tool that assumes you have two hands and 30 seconds of focus per entry."
+  - question: "Can I use Notion to track a renovation budget?"
+    answer: "You can build a budget database in Notion and it'll work well at the desk — formulas, rollups, category totals. The problem is the same one spreadsheets have: it goes stale the moment logging requires effort you don't have on-site. A budget tracker only protects you if it's current, and a desk-first tool quietly drifts out of date once execution starts. For the live running balance, a phone-first app keeps it accurate without nightly catch-up admin."
+  - question: "What's the difference between Notion and a dedicated renovation app?"
+    answer: "Notion is a general-purpose workspace you shape into anything — which makes it powerful for planning and high-friction for a specific repetitive task like on-site logging. A dedicated renovation app like Home Stories does one job: it makes capturing a cost, photo, or task on your phone take seconds, with a budget structure already built in. You trade Notion's infinite flexibility for speed at the one task you'll do hundreds of times during a build."
+  - question: "Should I use Notion or an app for my renovation?"
+    answer: "Use Notion for the planning phase — research, mood boards, contractor shortlists, document storage — where its flexibility is a genuine advantage. Switch to (or add) a phone-first app like Home Stories for the execution phase, where the job is fast, repeated, on-site logging. Most people who try to run the whole project in Notion abandon the budget tracking around week three for exactly the same reason spreadsheets fail: the tool needs a desk, and the renovation is happening in a half-demolished room."
+  - question: "Is Home Stories free?"
+    answer: "Yes — Home Stories is free on the App Store for iPhone, with an optional one-time Premium Lifetime upgrade. It's built specifically for renovations rather than being a general productivity tool, with budget tracking, a photo timeline, task management, and PDF export. It requires iOS 17 or later."
+relatedSlugs:
+  - "renovation-spreadsheet-alternative"
+  - "how-to-budget-a-home-renovation"
+  - "renovation-budget-template"
+---
+
+If you spend any time in renovation forums, you'll find two camps that talk past each other. One swears Notion is the only tool you need — they'll share a screenshot of a beautiful renovation hub with linked databases and a mood board that looks like a magazine spread. The other gave up on Notion three weeks into their actual build and can't quite explain why, only that it "stopped working."
+
+Both camps are right. They're just describing different halves of a renovation. Notion is a genuinely excellent tool for one half and a genuinely frustrating one for the other, and the line between them is sharp enough to be worth drawing carefully. This isn't a hit piece on Notion — I like Notion, and there's a specific phase where it beats almost everything. It's a map of where it wins, where it doesn't, and why "where" turns out to matter more than "features."
+
+![A renovator sitting on the floor of a half-finished room reviewing plans and samples on a tablet and phone](/stock/05.webp)
+
+## The two halves of a renovation
+
+Every renovation has a planning half and an execution half, and they have almost nothing in common.
+
+**Planning** happens at a desk, over weeks, in a calm head. You're researching, comparing quotes, collecting inspiration, mapping out rooms, storing documents. The work is reflective. You have both hands, a screen, and time to make things tidy.
+
+**Execution** happens on-site, over months, in a chaotic environment. You're logging a $340 receipt at the builder's merchant, snapping a photo of the first-fix wiring before it's plastered over, ticking off a task while a contractor waits for an answer. The work is reactive. You have one hand, a dusty phone, and about ten seconds before the moment's gone.
+
+A tool that's perfect for the first half can be actively wrong for the second. That's the whole story of Notion in a renovation — and it's the same fault line that makes [a spreadsheet stop working halfway through](/blog/renovation-spreadsheet-alternative/).
+
+## Where Notion genuinely wins: planning
+
+Let me be clear about this, because the rest of the post is going to be more critical: for the planning phase, Notion is one of the best tools that exists. If you're in the months before work starts, this is a real recommendation.
+
+Here's what it does well:
+
+- **A flexible renovation hub.** One workspace with room-by-room pages, a budget database, a contractor list, and a document store, all cross-linked. Nothing else gives you this much freedom to model the project the way *you* think about it.
+- **Contractor research.** A database with one row per trade — quote, availability, references, notes, the gut-feel rating — sortable and filterable. This is genuinely better than a spreadsheet for the comparison stage.
+- **Mood boards and inspiration.** Embed images, drop in links, build a visual board per room. Notion handles this gracefully where a spreadsheet would choke.
+- **Document storage.** Quotes, permits, warranties, plans — all attached where they belong instead of buried in email.
+- **Quote comparison.** Three kitchen quotes side by side with a formula totalling each? Notion does this cleanly.
+
+If your renovation hasn't started yet, build this hub. You'll use it before, during, and after the project, and the time spent structuring your thinking up front is never wasted. None of what follows is an argument against doing this.
+
+## Where Notion struggles: execution
+
+The trouble starts the day the work does. The same flexibility that makes Notion brilliant for planning becomes friction for the one task you're now going to do hundreds of times: logging what just happened, from your phone, on-site.
+
+**The mobile app is a desk tool in your pocket.** Notion's phone app is capable, but it's a shrunken version of a desktop workspace, not a tool designed for speed. Adding a budget entry on-site means opening the app, finding the right database, opening a new row, filling several properties, attaching a photo, saving. It's perhaps 30–45 seconds of focused tapping. That sounds trivial until you're doing it one-handed, in a dusty room, with a contractor mid-sentence — and so you don't do it. You tell yourself you'll catch up Sunday.
+
+**Catching up Sunday doesn't work.** By Sunday you can't remember which receipt was the $112 one and which was the $340 one. You enter a "miscellaneous" line and tell yourself it's fine. The budget database — which only protects you if it's *current* — quietly drifts a week behind, then two, then it's a relic you don't open. This is precisely the failure pattern spreadsheets have, for precisely the same reason: the friction of logging exceeds the focus you have on-site.
+
+**Budget maths is manual.** You can build rollups and formulas, but you have to build and maintain them. There's no renovation-specific structure out of the box — no built-in contingency handling, no sense of the [phases of a renovation](/blog/home-renovation-phases/), no understanding that a "budget" has a planned figure, an actual figure, and a remaining buffer that should be watched as a live balance. You're constructing all of that yourself, and then maintaining it by hand, on a phone, during the busiest months of the project.
+
+**No purpose-built photo timeline.** You *can* attach photos in Notion. But a renovation generates a chronological visual record — before, during, behind-the-wall, after — and Notion has no native concept of that timeline. You end up with photos scattered across pages instead of a single dated progression you can scroll.
+
+None of these is a flaw in Notion as a product. They're the cost of generality. A tool that can be anything isn't optimised for the one repetitive thing a live renovation demands.
+
+## Where Home Stories wins: the on-site logging job
+
+[Home Stories](https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960) is the opposite trade-off. It can't be a contractor CRM or a mood board, and it doesn't try. It does one job: make capturing a cost, a photo, a task, or a note take seconds on your phone while you're standing in the room.
+
+What that buys you in the execution phase:
+
+- **One-handed logging.** A cost is a couple of taps and a photo of the receipt — fast enough that you actually do it at the merchant's counter, not "later." Because you log in the moment, the data stays accurate.
+- **A budget that's already structured for renovations.** Planned versus actual, category totals, and a [contingency buffer](/blog/renovation-contingency-budget/) you can watch drain in real time — no formulas to build or maintain. Log a surprise cost and the remaining buffer updates instantly.
+- **A photo timeline by default.** Photos land in a dated, chronological record — the visual history of the project — without you organising anything.
+- **Task tracking that lives where the work is.** Tick things off from the site, not from a desk you're rarely at during a build.
+- **PDF export.** A clean summary for your records, your accountant, or your own sanity at handover.
+
+The point isn't that Home Stories has more features than Notion — it deliberately has fewer. It's that the features it has are pointed at the exact task Notion makes hardest, and removing the friction from that task is what keeps the data honest for the whole build.
+
+## Side by side
+
+| | **Notion** | **Home Stories** |
+|---|---|---|
+| Planning hub & free-form pages | Excellent | Not its job |
+| Contractor research database | Excellent | Limited |
+| Mood boards / inspiration | Excellent | Not its job |
+| Document storage | Strong | Limited |
+| On-site cost logging | Slow, high-friction | Fast, phone-first |
+| Renovation-specific budget structure | Build it yourself | Built in |
+| Contingency / live running balance | Manual | Built in |
+| Photo timeline | Scattered | Chronological by default |
+| Best phase | Before work starts | Once work is underway |
+
+Read down that table and the pattern is obvious: the two tools win in almost perfectly opposite columns. That's not a coincidence — it's the planning/execution split showing up feature by feature.
+
+## The honest recommendation: most people want both
+
+This isn't a "switch to the app and delete Notion" post. The genuinely useful setup for most renovators is to let each tool do the half it's good at:
+
+1. **Plan in Notion.** Build the hub before work starts — contractor database, quote comparisons, mood boards, document store, room pages. Lean into its flexibility. This is where it's worth the time.
+2. **Execute in a phone-first app.** The day demolition starts, the job changes from *thinking* to *capturing*. That's when a desk tool quietly fails and a phone-first tracker earns its place. Log costs, photos, and tasks as they happen, and keep the budget as a live balance.
+
+The two don't really compete; they hand off. Notion holds the static planning artefacts you'll refer back to. The app holds the live, fast-moving record of what's actually happening on-site. The handoff point is roughly the day the first wall comes down.
+
+And if you only want *one* new tool — if you've already got planning handled in Notion, a spreadsheet, or your head — then add the one for the part that actually breaks. The part that breaks is never the planning. It's keeping the budget honest while the work is underway, logging one-handed in a room full of dust. That's the part Notion handles worst, and the part [Home Stories was built for](/blog/how-to-budget-a-home-renovation/).
+
+[Home Stories is free on the App Store](https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960) — keep your Notion hub for planning, and let a phone-first tracker carry the budget through the months when a desk tool can't.


### PR DESCRIPTION
## Summary

Adds Week 8 of the [blog content plan](https://github.com/12fdk/home-stories.12f.dk/issues/30): **Notion vs Home Stories for Renovation Planning** (comparison, primary keyword `notion for home renovation`).

An honest comparison framed around the planning vs execution split: Notion genuinely wins the planning phase (hub, contractor research, mood boards), a phone-first tracker wins the on-site execution phase (one-handed cost/photo/task logging, live budget balance). Includes a side-by-side feature table and the standard structure (H1 → lede → TL;DR → body → mid-CTA → FAQ → related → end-CTA).

## Internal linking
- Inbound link added context from `renovation-spreadsheet-alternative` (already name-checks Notion)
- Cross-links to budgeting guide, contingency, phases, and budget-template posts
- `relatedSlugs` set for the related-posts component

## Verification
- `pnpm build` in Docker passes — post page, auto-generated OG image (`/og/notion-for-home-renovation.png`), and RSS entry all produced
- Rendered page reviewed in browser: title, byline + reading time, TL;DR box, body headings, comparison table, and FAQ all render cleanly
- FAQ schema markup included via frontmatter `faq`

Refs #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)