### PR TITLE
Add Week 9 blog post: How to Organize Renovation Receipts for Tax & Insurance (#30)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,7 @@
 FROM node:20-alpine
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Pinned to match CI (.github/workflows/deploy.yml) — pnpm 10+ requires Node 22.13+
+RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 WORKDIR /app
 

--- a/src/content/blog/how-to-organize-renovation-receipts.md
+++ b/src/content/blog/how-to-organize-renovation-receipts.md
@@ -1,0 +1,112 @@
+---
+title: "How to Organize Renovation Receipts for Tax & Insurance"
+description: "A shoebox of faded receipts costs you money at tax time and at claim time. Here's a capture-once system that keeps every renovation cost provable for years."
+lede: "Your renovation receipts are worth real money — but only if you can still find them, read them, and prove what they were for, years after the dust settles. Capital improvements can reduce the tax you owe when you sell, and an insurance claim is only ever as good as the evidence behind it. This is a practical, capture-once system for keeping every cost provable long after the project ends."
+keyword: "how to organize renovation receipts"
+publishDate: 2026-07-11
+author: "Robert Jensen"
+tags: ["budgeting", "organization", "tax", "insurance"]
+tldr:
+  - "<strong>Renovation receipts have two long-term jobs:</strong> reducing your taxable gain when you eventually sell, and proving value if you ever make an insurance claim. Both jobs happen years after the receipt lands in your pocket."
+  - "<strong>Capture at the point of sale, not at the kitchen table.</strong> A receipt photographed in the car park is a receipt you have; one you 'file properly later' is one you've already lost."
+  - "<strong>A receipt on its own is nearly useless.</strong> It needs four things attached: date, amount, what it was for, and which room or project it belongs to."
+  - "<strong>Learn the split between improvements and repairs.</strong> In most tax systems only the first kind adds to your home's cost basis — so tag it at capture time, while you still remember."
+  - "<strong>Digital, backed up, and exportable.</strong> Thermal paper fades within a year or two; a folder in a drawer doesn't survive a house fire. Home Stories captures the photo, cost, and room in one step and <a href='https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960'>exports the lot as a PDF</a>."
+faq:
+  - question: "Should I keep renovation receipts for taxes?"
+    answer: "In most tax systems, yes — money you spend on capital improvements (work that adds value or extends the life of the property, like a new kitchen, an extension, or a new roof) is typically added to your home's cost basis, which can reduce the taxable gain when you sell. Routine repairs and maintenance usually aren't. Rules vary significantly by country and change over time, so treat this as a reason to keep good records rather than as tax advice — and check the specifics with a qualified tax professional for your jurisdiction."
+  - question: "How long should I keep home improvement receipts?"
+    answer: "The safe general rule is: for as long as you own the home, plus the statutory record-retention period after you sell it — because the improvement receipt only becomes relevant at the point of sale, potentially decades later. That's far longer than thermal receipt paper survives, which is why digital copies matter more here than in almost any other kind of record-keeping. Confirm the exact retention period that applies where you live with a tax professional."
+  - question: "What information do I need on a renovation receipt?"
+    answer: "Four things, at minimum: the date, the amount, a clear description of what was bought or done, and which room or project it belongs to. Receipts from builders' merchants are notorious for cryptic product codes, so add a plain-language note at capture time ('oak flooring, main bedroom') — in three years the code will mean nothing to you. For contractor work, keep the invoice, the contract or quote, and proof of payment together, and photograph the finished work as supporting evidence."
+  - question: "Do I need receipts for a home insurance claim?"
+    answer: "You don't always need them to file a claim, but they dramatically strengthen it. Proof of purchase and dated photos establish what existed, what it cost, and when it was installed — which is exactly what an insurer needs to settle at the right value rather than a depreciated estimate. Renovations are also a common reason to be under-insured: if you've added significant value, tell your insurer, or you may find the rebuild cover no longer matches the house you actually own."
+  - question: "What's the best way to organize renovation receipts?"
+    answer: "Capture digitally at the point of sale, tag each receipt with the room and whether it's an improvement or a repair, and keep everything in one place that survives the project. A physical shoebox fails on all three counts — it needs a second filing step you'll skip, the paper fades, and it doesn't survive a fire or a flood. A phone-first renovation app like Home Stories logs the photo, the cost, and the room in one action while you're standing at the till, then exports the whole record as a PDF when you need it."
+relatedSlugs:
+  - "how-to-budget-a-home-renovation"
+  - "renovation-budget-template"
+  - "home-renovation-phases"
+---
+
+There's a shoebox in a lot of houses. It sits on top of a wardrobe, and it contains the entire paper history of a renovation: crumpled builders' merchant slips, a folded contractor invoice, a till receipt for tiles that has faded to a blank grey rectangle, and — somewhere near the bottom — a warranty certificate for a boiler that stopped working last winter.
+
+The shoebox represents thousands of dollars in evidence that no longer works. And the frustrating part is that it only fails you *later* — at the moment you sell the house and your accountant asks what you spent on improvements, or the day a pipe bursts and the insurer wants to know what that floor actually cost. During the renovation, the shoebox felt like organization. It just wasn't.
+
+Getting this right isn't about being tidy. It's about the fact that a renovation receipt is a financial instrument with a very long fuse.
+
+![A homeowner sitting at a kitchen table in a half-renovated kitchen, reviewing an invoice with a spread of paper receipts and a phone in front of him](/stock/03.webp)
+
+## Why renovation receipts are worth real money
+
+Two things happen long after your project finishes, and both of them cash in on your record-keeping.
+
+**Tax when you sell.** In most tax systems, the money you put into *capital improvements* — work that adds value to the property or extends its life — is added to what the property cost you, which can reduce the taxable gain when you eventually sell. Routine repairs and maintenance generally don't count. The details vary a lot by country and they change over time, so the specifics belong with a qualified tax professional in your jurisdiction. But the universal part is this: **the deduction is only ever as good as the documentation behind it.** A remembered figure is not evidence. A receipt is.
+
+**Insurance when something goes wrong.** A claim is a negotiation about value, and proof wins it. Dated receipts and photos establish what existed, what it cost, and when it went in — the difference between an insurer settling at what you actually paid for your engineered oak floor and settling at a depreciated guess. Renovations are also one of the most common causes of being quietly *under-insured*: if you've meaningfully raised the value of your home, your rebuild cover may no longer match the house you now own. Tell your insurer — and keep the evidence that supports the new number.
+
+Both payoffs land years after the receipt does. That's the whole problem, and it's why "I'll sort it out at the end" is a strategy that never survives contact with a real renovation.
+
+## The one habit that makes all of this work
+
+Capture the receipt **at the point of sale**, not later.
+
+This sounds trivially small, and it is the single change that separates people who have a complete record from people who have a shoebox. Not because filing is hard, but because *later* never comes. You will not sit down on a Sunday and sort three weeks of builders' merchant slips into categories. Nobody does. The renovation is exhausting, the pile grows faster than your patience, and the whole system collapses into a container of paper you'll open once, several years from now, at exactly the wrong moment.
+
+So the rule is: the receipt gets captured before you leave the car park. Ten seconds, phone in hand, done. It's the same discipline that keeps a [renovation budget honest while work is underway](/blog/how-to-budget-a-home-renovation/) — the value isn't in the effort, it's in the fact that there's no second step to forget.
+
+## What a receipt needs attached to it
+
+A photo of a receipt, on its own, is only marginally better than the paper. Builders' merchant receipts in particular are close to unreadable after the fact — a column of product codes, a total, and no clue what any of it was for. Three years later, "SKU 4471-B / £238.40" tells you nothing you can use.
+
+Every captured cost needs four things:
+
+1. **Date** — usually on the receipt, but confirm it's legible in the photo.
+2. **Amount** — the real total you paid, including tax and delivery.
+3. **What it was for** — in plain language. "Oak flooring, main bedroom," not the product code.
+4. **Which room or project** — the thing that makes the record searchable later.
+
+And one optional field that pays for itself: **improvement or repair?** Tag it at capture time, while you still remember what the work was. That distinction is the one your accountant will care about, and reconstructing it from a stack of receipts years later is genuinely hard — you'll be squinting at a plumbing invoice trying to recall whether that was the new bathroom (improvement) or the leak you fixed the same week (repair).
+
+For contractor work, keep three documents together rather than one: the **quote or contract** (what was agreed), the **invoice** (what was charged), and **proof of payment** (that you actually paid it). Add a photo of the finished work and you have a complete, self-explaining record.
+
+## Photograph the things you can't photograph later
+
+There's a category of evidence that has a hard deadline: anything that's about to be covered up.
+
+Before the plasterboard goes on, photograph the first-fix wiring and pipework. Before the floor is laid, photograph the subfloor and any insulation. Before the tiles go up, photograph the waterproofing. Capture serial numbers and model plates on the boiler, the heat pump, the appliances — they're accessible for about a day, and then they're behind a unit forever.
+
+This is insurance evidence, warranty evidence, and future-buyer evidence all at once, and it costs about two minutes per phase. It's also, not coincidentally, the same set of photos that make a [phase-by-phase record of the renovation](/blog/home-renovation-phases/) actually useful when a contractor asks "what's behind this wall?" eighteen months from now.
+
+## Where the record needs to live
+
+Three failure modes kill renovation records, and any system worth using has to survive all of them.
+
+**Thermal paper fades.** Most till receipts are printed on thermal paper, and a warm loft or a sunny windowsill will reduce one to a blank slip within a year or two — well before it's needed. The photo isn't a backup of the receipt; before long, the photo *is* the receipt.
+
+**Filing requires a second step.** Any system where capturing and filing are separate actions will be abandoned mid-project. If logging the cost, attaching the photo, and tagging the room aren't one action, you'll do the first and skip the rest.
+
+**Paper doesn't survive the disaster it's meant to prove.** The receipts for your kitchen are stored... in your kitchen. A fire or a flood destroys the evidence and the thing it was evidence for, in one go. The record has to live somewhere else — synced, backed up, off-site.
+
+This is exactly the gap Home Stories was built for. You log the cost, snap the receipt, and tag the room in a single action at the till — no separate filing step, nothing to catch up on at the weekend. Everything stays attached to the project, and when your accountant or your insurer asks, you [export the whole record as a PDF](https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960) instead of tipping out a shoebox. It's free on the App Store.
+
+## How long to keep it all
+
+Longer than feels reasonable — which is the point most people get wrong.
+
+An improvement receipt doesn't do its job during the renovation. It does its job the day you sell, which might be fifteen years from now. So the working rule is: **keep improvement records for as long as you own the home, plus the statutory retention period after the sale.** Warranty and guarantee documents follow their own clock (keep them for the length of the warranty, at minimum), and insurance-relevant evidence is worth keeping for as long as the item exists.
+
+Retention periods and what qualifies as an improvement both vary by jurisdiction, so confirm the specifics with a tax professional where you live. But no advice you get will ever be "you kept too much" — the failure mode in this area runs entirely in one direction.
+
+## The system, in four lines
+
+1. **Capture at the till.** Photo, amount, description, room — before you leave the car park.
+2. **Tag it while you remember.** Improvement or repair; which room; what it actually was.
+3. **Photograph what's about to be hidden.** First fix, subfloor, waterproofing, serial numbers.
+4. **Keep it digital, backed up, and exportable** — for as long as you own the house.
+
+That's the whole thing. It takes ten seconds per receipt during the project, and it's worth a great deal more than that at the two moments when it matters.
+
+The alternative isn't chaos, exactly. It's a shoebox — which looks like a system right up until the day you need it, and then quietly isn't one.
+
+If you'd rather not keep a shoebox at all, [Home Stories is free on the App Store](https://apps.apple.com/dk/app/home-stories-renovation-app/id6754754960). Log each cost with its receipt photo and room as it happens, and export a complete, dated record of the whole renovation whenever your accountant, your insurer, or your buyer asks for one.


### PR DESCRIPTION
Week 9 of the blog content plan (#30).

## The post

**How to Organize Renovation Receipts for Tax & Insurance** — targets the keyword `how to organize renovation receipts` (~1,600 words, Tier B).

Follows the standard post structure: lede → TL;DR → body → mid-CTA → FAQ (5 PAA-mined questions, FAQPage schema) → related posts → end CTA. Internal links out to the budgeting guide, the 7-phases post, and the budget template; the image reuses `/stock/03.webp` (receipts and an invoice on a kitchen table), which fits this topic better than any of the others.

Tax content is deliberately kept general — it describes the capital-improvement vs. repair distinction as a principle and points readers to a qualified professional for their jurisdiction, rather than stating specific rules, thresholds, or retention periods that vary by country and change over time.

## Also: fixes a broken Docker build

`Dockerfile.dev` ran `corepack prepare pnpm@latest`, but pnpm 10+ requires Node 22.13+ while the image is `node:20-alpine`. pnpm crashed with `No such built-in module: node:sqlite`, the install silently left a stale `node_modules`, and every Docker build failed on `Rollup failed to resolve import "@astrojs/rss"`. Pinned to pnpm 9.15.9, matching CI (`deploy.yml`) and the `lockfileVersion: 9.0` lockfile.

This was broken before this branch and is unrelated to the post — happy to split it out if you'd rather.

## Verification

- `pnpm build` in Docker passes (14 pages).
- Post is present in `rss.xml` and `sitemap-0.xml`, and emits valid FAQPage schema.
- Rendered in a browser: H1, lede, TL;DR box, inline image, mid-CTA, 5-question FAQ accordion, author bio, 3 related-post cards, and end CTA all render. Clicking through a related card resolves to `/blog/home-renovation-phases/` with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjBX8JZvPNZriotRBoRsDw