### PR TITLE
Stop submitting non-pages to Google

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -42,10 +42,11 @@ export default defineConfig({
     sitemap({
       changefreq: "weekly",
       priority: 0.7,
-      customPages: [
-        "https://home-stories.12f.dk/llms.txt",
-        "https://home-stories.12f.dk/llms-full.txt",
-      ],
+      // A sitemap is a list of pages we want indexed. /app is a redirect stub
+      // (noindexed), and llms.txt / llms-full.txt are plain-text files for AI
+      // crawlers — Google parks those at "crawled, currently not indexed"
+      // forever. They stay in robots.txt; they just don't belong here.
+      filter: (page) => !page.includes("/app/"),
       serialize(item) {
         // Homepage gets highest priority
         if (item.url === "https://home-stories.12f.dk/") {
@@ -56,11 +57,6 @@ export default defineConfig({
         if (item.url.includes("privacy-policy") || item.url.includes("terms-and-conditions") || item.url.includes("cookies-policy")) {
           item.priority = 0.3;
           item.changefreq = "yearly";
-        }
-        // App redirect page
-        if (item.url.includes("/app")) {
-          item.priority = 0.5;
-          item.changefreq = "monthly";
         }
         return item;
       },

--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -2,8 +2,8 @@
 import "@styles/styles.scss";
 import type { TemplateConfig } from "utils/configType";
 
-const { backgroundGrid, seo, logo, theme, forceTheme, appStoreLink, name, appStore } =
-  Astro.props as TemplateConfig;
+const { backgroundGrid, seo, logo, theme, forceTheme, appStoreLink, name, appStore, noindex } =
+  Astro.props as TemplateConfig & { noindex?: boolean };
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImage = logo.startsWith("http") ? logo : new URL("/og-image.png", Astro.site).href;
@@ -44,7 +44,12 @@ const ratingCount = appStore?.ratingCount && appStore.ratingCount > 0 ? String(a
     <meta name="description" content={seo.description} />
     <meta name="keywords" content="home renovation app, renovation tracker, home improvement app, project management, budget tracking, renovation budget, home project planner, renovation photos, before after renovation, iOS renovation app, iPhone home app, renovation journal, home remodel tracker, renovation progress, DIY project tracker, home renovation planner, renovation cost tracker, home improvement tracker, renovation organizer, free renovation app" />
     <meta name="author" content="Robert Jensen" />
-    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
+    <meta
+      name="robots"
+      content={noindex
+        ? "noindex, follow"
+        : "index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"}
+    />
     <meta name="application-name" content="Home Stories" />
 
     <!-- AI/LLM Discovery -->

--- a/src/pages/app.astro
+++ b/src/pages/app.astro
@@ -2,8 +2,16 @@
 import AppRedirectionPage from "@modules/app"
 import Layout from "Layout.astro";
 import defaultTemplateConfig from "utils/config";
+
+// A redirect stub, not a page: it bounces to the App Store and has no content
+// of its own. Left indexable it reads to Google as a soft 404, and its title
+// duplicated the homepage's. Noindexed here, and excluded from the sitemap.
+const seo = {
+  title: "Opening Home Stories in the App Store",
+  description: "Redirecting you to Home Stories on the App Store.",
+};
 ---
 
-<Layout {...defaultTemplateConfig}>
+<Layout {...defaultTemplateConfig} seo={seo} noindex>
   <AppRedirectionPage client:load config={defaultTemplateConfig} />
 </Layout>


### PR DESCRIPTION
Closes #57

Nothing on the site blocks indexing — `robots.txt` allows all, there is no `noindex` or `X-Robots-Tag`, and canonicals are correct. But three sitemap URLs were never indexable content, and Search Console was counting them as failures.

## Changes

**`/app/` — a redirect stub that asked to be indexed.** It bounces to the App Store, has no content of its own ("We're sending you to our app"), carried **the same `<title>` as the homepage**, and had a self-referencing canonical. Google reads that as a soft 404 / duplicate. Now `noindex, follow`, with its own title, and excluded from the sitemap.

**`llms.txt` / `llms-full.txt` — text files, not pages.** Submitted via `customPages`, they would sit at "Crawled – currently not indexed" permanently and inflate the count. They remain in `robots.txt` and are still served to AI crawlers — they are simply no longer offered to Google as pages.

`Layout` gains a `noindex` prop. Every other page stays `index, follow`.

## Verification

Built and checked `dist/`:
- Sitemap: **22 → 19 URLs** (`/app/`, `llms.txt`, `llms-full.txt` gone)
- `/app/index.html` → `<meta name="robots" content="noindex, follow">`
- Homepage and blog posts → still `index, follow`
- `llms.txt`, `llms-full.txt`, `ai.txt` still present in `dist/` and still referenced from `robots.txt`
- `astro check` clean (0 errors)

## What this does not fix

The main gap — 14 pages known, 2 indexed — is almost certainly **"Discovered/Crawled – currently not indexed"**: a ~3-month-old domain with little authority. No technical change overrides that; it is earned through links and traffic. This PR only stops the URLs that should never have been candidates from polluting the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TSizUb4R19kYB24qrb4dx