### PR TITLE
Fix future-dated posts, add sitemap lastmod, link blog from homepage

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,38 @@
 import { defineConfig } from "astro/config";
+import fs from "node:fs";
+import path from "node:path";
 import react from "@astrojs/react";
 import tailwind from "@astrojs/tailwind";
 import sitemap from "@astrojs/sitemap";
+
+const SITE = "https://home-stories.12f.dk";
+const BLOG_DIR = "src/content/blog";
+
+/**
+ * lastmod per blog post, read from its own frontmatter (updatedDate if it has
+ * one, else publishDate). Google distrusts a sitemap whose lastmod it can't
+ * believe, so a date is only emitted when we actually know it — never guessed,
+ * never in the future.
+ */
+function blogLastmod() {
+  const dates = new Map();
+  const today = new Date();
+
+  for (const file of fs.readdirSync(BLOG_DIR)) {
+    if (!file.endsWith(".md")) continue;
+    const raw = fs.readFileSync(path.join(BLOG_DIR, file), "utf8");
+    const stamp = (
+      raw.match(/^updatedDate:\s*(\S+)/m)?.[1] ??
+      raw.match(/^publishDate:\s*(\S+)/m)?.[1]
+    )?.replace(/['"]/g, "");
+    if (!stamp) continue;
+
+    const date = new Date(stamp);
+    if (Number.isNaN(date.valueOf()) || date > today) continue;
+    dates.set(`${SITE}/blog/${file.replace(/\.md$/, "")}/`, date);
+  }
+  return dates;
+}
 
 // https://astro.build/config
 export default defineConfig({
@@ -49,7 +80,7 @@ export default defineConfig({
       filter: (page) => !page.includes("/app/"),
       serialize(item) {
         // Homepage gets highest priority
-        if (item.url === "https://home-stories.12f.dk/") {
+        if (item.url === `${SITE}/`) {
           item.priority = 1.0;
           item.changefreq = "weekly";
         }
@@ -57,6 +88,17 @@ export default defineConfig({
         if (item.url.includes("privacy-policy") || item.url.includes("terms-and-conditions") || item.url.includes("cookies-policy")) {
           item.priority = 0.3;
           item.changefreq = "yearly";
+        }
+
+        const posts = blogLastmod();
+        const lastmod = posts.get(item.url);
+        if (lastmod) {
+          item.lastmod = lastmod.toISOString();
+        } else if (item.url === `${SITE}/blog/` && posts.size > 0) {
+          // The index changes when its newest post does.
+          item.lastmod = new Date(
+            Math.max(...[...posts.values()].map((d) => d.valueOf()))
+          ).toISOString();
         }
         return item;
       },

--- a/src/content/blog/best-home-improvement-apps.md
+++ b/src/content/blog/best-home-improvement-apps.md
@@ -3,7 +3,7 @@ title: "6 Best Home Improvement Apps for iPhone in 2026"
 description: "Most round-ups still recommend an app abandoned in 2022. Here are six iPhone apps that are actually maintained — and the job each one really does."
 lede: "There is no single best home improvement app, because a renovation isn't a single job. Finding a contractor, measuring a room, designing a layout, and keeping the budget honest while the dust flies are four different problems, and the apps that are brilliant at one are usually hopeless at the others. Here are six iPhone apps worth your home screen in 2026 — checked against the App Store, not copied from other lists."
 keyword: "best home improvement apps 2026"
-publishDate: 2026-07-20
+publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["apps", "tools", "planning", "reviews"]
 tldr:

--- a/src/content/blog/how-to-plan-a-home-renovation-step-by-step.md
+++ b/src/content/blog/how-to-plan-a-home-renovation-step-by-step.md
@@ -3,7 +3,7 @@ title: "How to Plan a Home Renovation Step by Step (2026 Guide)"
 description: "Step-by-step guide to planning a home renovation in 2026 — from the first decision to the final walkthrough. Real numbers, real timelines."
 lede: "Planning a home renovation doesn't have to mean spreadsheets, anxiety, and surprises that blow your budget. The right approach breaks the entire process into discrete, manageable steps — each with a clear start, a clear deliverable, and a clear next step. This guide walks you through every phase of a home renovation, from the very first decision to the final walkthrough, with realistic timelines and costs so you know exactly what comes next."
 keyword: "how to plan a home renovation step by step"
-publishDate: 2026-08-17
+publishDate: 2026-07-14
 author: "Robert Jensen"
 tags: ["planning", "step-by-step", "first-timer", "guide"]
 tldr:

--- a/src/content/blog/how-to-track-home-improvement-expenses.md
+++ b/src/content/blog/how-to-track-home-improvement-expenses.md
@@ -3,7 +3,7 @@ title: "How to Track Home Improvement Expenses (4 Methods Compared)"
 description: "Four methods to track home improvement expenses — spreadsheet, Notion, a dedicated app, and receipts-in-a-jar — compared on what actually works on-site."
 lede: "Tracking home improvement expenses only matters if you're doing it on-site, where the money actually leaks. This post compares four methods on the single metric that matters: will you still be logging after three weeks of dust, decision fatigue, and contractor delays?"
 keyword: "how to track home improvement expenses"
-publishDate: 2026-07-27
+publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["budgeting", "planning", "how-to"]
 tldr:

--- a/src/content/blog/kitchen-renovation-timeline.md
+++ b/src/content/blog/kitchen-renovation-timeline.md
@@ -3,7 +3,7 @@ title: "A Realistic Kitchen Renovation Timeline (Week-by-Week)"
 description: "A realistic kitchen renovation timeline — week by week, from design to the final walkthrough — with real durations and hidden steps."
 lede: "Most kitchen renovation timelines are optimistic by 30–40%. They assume everything arrives on time, inspections pass first try, and your contractor has no other jobs bleeding into yours. This timeline shows what actually happens on a real kitchen renovation in 2026 — the weeks you plan for and the ones you don't."
 keyword: "renovation project timeline example"
-publishDate: 2026-08-03
+publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["kitchen", "planning", "timeline", "how-to"]
 tldr:

--- a/src/content/blog/renovation-cost-overrun-statistics.md
+++ b/src/content/blog/renovation-cost-overrun-statistics.md
@@ -3,7 +3,7 @@ title: "Renovation Cost Overrun Statistics: What the Data Actually Says"
 description: "We analyzed 200 renovation projects: average cost overrun is 15–30%. Here's the data on why it happens and how to protect your budget."
 lede: "Renovations regularly go 15–30% over budget, and the data shows it's not a bug — it's a structural feature of how renovations are planned. The overrun isn't randomness; it's the gap between optimistic pre-project estimates and the inevitable surprises that surface once the walls open. Size your contingency to the evidence, not the folklore."
 keyword: "renovation cost overrun statistics"
-publishDate: 2026-08-10
+publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["budgeting", "statistics", "planning"]
 tldr:

--- a/src/modules/home/_components/fromTheBlog/index.tsx
+++ b/src/modules/home/_components/fromTheBlog/index.tsx
@@ -1,0 +1,80 @@
+import { motion } from "framer-motion";
+import SectionHeading from "../../../../components/sectionHeading";
+
+export interface BlogTeaser {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  minutes: number;
+}
+
+interface Props {
+  posts: BlogTeaser[];
+}
+
+/**
+ * The homepage links straight into the blog cluster. Without this every post
+ * hangs off a single index page, which is a thin path for both readers and
+ * crawlers.
+ */
+function FromTheBlog({ posts }: Props) {
+  if (!posts.length) return null;
+
+  return (
+    <section
+      id="writing"
+      className="mx-auto max-w-screen-lg px-4 py-20 md:py-28"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-6">
+        <SectionHeading
+          label="Writing"
+          title="What we've learned about budgets"
+          subtitle="Notes from renovations that went over, and the ones that didn't."
+        />
+        <a
+          href="/blog/"
+          className="tick-label shrink-0 border-b-2 border-accent pb-1 text-base-content transition-colors hover:text-primary"
+        >
+          All posts
+        </a>
+      </div>
+
+      <ul className="mt-12 list-none divide-y divide-base-300 border-y border-base-300 p-0">
+        {posts.map((post, index) => (
+          <motion.li
+            key={post.slug}
+            initial={{ opacity: 0, y: 12 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-60px" }}
+            transition={{
+              duration: 0.45,
+              delay: index * 0.06,
+              ease: [0.16, 1, 0.3, 1],
+            }}
+            className="m-0 p-0"
+          >
+            <a
+              href={`/blog/${post.slug}/`}
+              className="group flex flex-col gap-2 py-6 md:flex-row md:items-baseline md:gap-8"
+            >
+              <span className="tick-label shrink-0 text-base-content/40 md:w-40">
+                {post.date} · {post.minutes} min
+              </span>
+              <span className="flex-1">
+                <span className="block font-display text-xl font-bold tracking-tight text-base-content transition-colors group-hover:text-primary md:text-2xl">
+                  {post.title}
+                </span>
+                <span className="mt-1 block text-base-content/70">
+                  {post.description}
+                </span>
+              </span>
+            </a>
+          </motion.li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default FromTheBlog;

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -11,13 +11,15 @@ import Faq from "./_components/faq";
 import HowItWorks from "./_components/howItWorks";
 import Testimonials from "./_components/testimonials";
 import VideoDemo from "./_components/videoDemo";
+import FromTheBlog, { type BlogTeaser } from "./_components/fromTheBlog";
 import StickyDownload from "../../components/stickyDownload";
 
 interface Props {
   config: TemplateConfig;
+  posts?: BlogTeaser[];
 }
 
-function Home({ config }: Props) {
+function Home({ config, posts = [] }: Props) {
   return (
     <ConfigContext.Provider value={config}>
       <MotionConfig reducedMotion="user">
@@ -29,6 +31,7 @@ function Home({ config }: Props) {
           <VideoDemo />
           <HowItWorks />
           <Testimonials />
+          <FromTheBlog posts={posts} />
           <Faq />
           <AppBanner />
         </main>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,12 +1,30 @@
 ---
+import { getCollection } from "astro:content"
 import HomePage from "@modules/home"
 import Layout from "Layout.astro"
 import defaultTemplateConfig from "utils/config"
 import { fetchAppStoreData, fallbackAppStoreData, toAppStoreMetadata } from "utils/appStoreData"
+import { readingTime } from "utils/readingTime"
 import type { TemplateConfig } from "utils/configType"
 
 // Fetch App Store data at build time
 const appStoreData = await fetchAppStoreData() ?? fallbackAppStoreData;
+
+// The three newest posts, linked from the homepage so the blog cluster has a
+// path in from the site's strongest page.
+const posts = (await getCollection("blog", ({ data }) => !data.draft))
+  .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime())
+  .slice(0, 3)
+  .map((post) => ({
+    slug: post.slug,
+    title: post.data.title,
+    description: post.data.description,
+    date: post.data.publishDate.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+    }),
+    minutes: readingTime(post.body).minutes,
+  }));
 
 // Merge App Store data with default config
 const config: TemplateConfig = {
@@ -20,5 +38,5 @@ const config: TemplateConfig = {
 ---
 
 <Layout {...config}>
-  <HomePage client:load config={config} />
+  <HomePage client:load config={config} posts={posts} />
 </Layout>


### PR DESCRIPTION
Follow-up to #57 / #58, acting on the Search Console reason breakdown: **12 "Discovered – currently not indexed"**, 1 "Crawled – not indexed", 1 benign "alternate page with proper canonical". Nothing is blocked — the pages just are not being crawled. Three things were making that worse.

## 1. Five posts were dated in the future

They were **live, returning HTTP 200, and claiming a `publishDate` up to a month from now** (`2026-08-17`; today is `2026-07-14`) — including in their `datePublished` structured data. The blog index listed articles as published in August.

That is a low-trust signal, and it also makes `lastmod` unusable: a sitemap whose dates Google cannot believe gets its `lastmod` disregarded.

Re-dated to **the day each post actually shipped, from git history**:

| post | was | now |
|---|---|---|
| best-home-improvement-apps | 2026-07-20 | 2026-07-13 |
| how-to-track-home-improvement-expenses | 2026-07-27 | 2026-07-13 |
| kitchen-renovation-timeline | 2026-08-03 | 2026-07-13 |
| renovation-cost-overrun-statistics | 2026-08-10 | 2026-07-13 |
| how-to-plan-a-home-renovation-step-by-step | 2026-08-17 | 2026-07-14 |

Note these were **not** spread into a tidy weekly cadence. Git shows all five were committed on 13–14 July; the weekly dates in the frontmatter were a content calendar, not a publication record. Backdating them would have asserted to Google and to readers that they existed before they did.

## 2. Sitemap had no `lastmod`

Google had no signal about what to prioritise. Now derived per post from `updatedDate ?? publishDate`, and only emitted when the date is actually known and **not in the future**.

## 3. The homepage linked to zero blog posts

Every post hung off the single `/blog/` index — no path into the cluster from the site's strongest page. The three newest posts are now linked from the homepage, **server-rendered into the static HTML** (verified in `dist/index.html`, so crawlers see them without executing JS).

## Verification

- No future dates remain anywhere: frontmatter, sitemap `lastmod`, or `datePublished`
- Sitemap emits `lastmod` for all 14 posts + the blog index; none in the future
- 3 post links present in static `dist/index.html`
- `astro check` clean (0 errors), build green, section checked in-browser

## Honest expectation

This does **not** fix the main gap. 12 pages sitting at "Discovered" is a ~3-month-old domain with little authority — that is earned through links, not configured. This removes the self-inflicted obstacles and gives Google a reason to come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TSizUb4R19kYB24qrb4dx