### PR TITLE
Add cover images to the blog overview

### DIFF
--- a/src/components/blog/RelatedPosts.astro
+++ b/src/components/blog/RelatedPosts.astro
@@ -12,14 +12,29 @@ const { posts } = Astro.props;
   posts.length > 0 && (
     <section class="not-prose my-12 border-t border-base-300 pt-10">
       <h2 class="mb-6 text-2xl font-bold sm:text-3xl">Keep reading</h2>
-      <ul class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <ul class="grid list-none gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3">
         {posts.map((post) => (
-          <li class="rounded-xl border border-base-300 bg-base-100 p-5 transition hover:border-primary">
-            <a href={`/blog/${post.slug}/`} class="block">
-              <h3 class="mb-2 text-lg font-semibold text-base-content">
-                {post.data.title}
-              </h3>
-              <p class="text-sm text-base-content/70">{post.data.description}</p>
+          <li class="group m-0 overflow-hidden rounded-box border border-base-300 bg-base-100 p-0 transition-colors hover:border-base-content/30">
+            <a href={`/blog/${post.slug}/`} class="flex h-full flex-col">
+              {post.data.cover && (
+                <img
+                  src={post.data.cover}
+                  alt={post.data.coverAlt ?? ""}
+                  width={400}
+                  height={225}
+                  loading="lazy"
+                  decoding="async"
+                  class="aspect-[16/9] w-full border-b border-base-300 object-cover"
+                />
+              )}
+              <div class="p-5">
+                <h3 class="mb-2 font-display text-lg font-bold tracking-tight text-base-content transition-colors group-hover:text-primary">
+                  {post.data.title}
+                </h3>
+                <p class="text-sm leading-relaxed text-base-content/70">
+                  {post.data.description}
+                </p>
+              </div>
             </a>
           </li>
         ))}

--- a/src/content/blog/best-home-improvement-apps.md
+++ b/src/content/blog/best-home-improvement-apps.md
@@ -3,6 +3,8 @@ title: "6 Best Home Improvement Apps for iPhone in 2026"
 description: "Most round-ups still recommend an app abandoned in 2022. Here are six iPhone apps that are actually maintained — and the job each one really does."
 lede: "There is no single best home improvement app, because a renovation isn't a single job. Finding a contractor, measuring a room, designing a layout, and keeping the budget honest while the dust flies are four different problems, and the apps that are brilliant at one are usually hopeless at the others. Here are six iPhone apps worth your home screen in 2026 — checked against the App Store, not copied from other lists."
 keyword: "best home improvement apps 2026"
+cover: "/stock/02.webp"
+coverAlt: "A renovator kneeling on a bare concrete floor, checking a phone beside stacked tile and flooring samples"
 publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["apps", "tools", "planning", "reviews"]

--- a/src/content/blog/home-renovation-phases.md
+++ b/src/content/blog/home-renovation-phases.md
@@ -3,6 +3,8 @@ title: "The 7 Phases of a Home Renovation (and What to Track)"
 description: "The 7 phases of a home renovation, in order — and exactly what to track in each one so the project lands on time, on budget, and on plan."
 lede: "Every home renovation moves through the same seven phases, whether it's a single bathroom or a whole house. Knowing the sequence — and the one or two things that actually matter to track in each phase — is what separates a project that stays on plan from one that drifts."
 keyword: "home renovation phases"
+cover: "/stock/08.png"
+coverAlt: "A room stripped back to timber studs and ceiling joists, with wiring run and windows unfinished"
 publishDate: 2026-06-08
 author: "Robert Jensen"
 tags: ["planning", "phases", "how-to"]

--- a/src/content/blog/homezada-vs-houzz-pro.md
+++ b/src/content/blog/homezada-vs-houzz-pro.md
@@ -3,6 +3,8 @@ title: "HomeZada vs Houzz Pro vs Home Stories: Honest 2026 Review"
 description: "HomeZada, Houzz Pro, and Home Stories compared — which renovation app is right for your project in 2026? Feature-by-feature breakdown."
 lede: "HomeZada is the feature-heavy veteran, Houzz Pro targets contractors rather than homeowners, and Home Stories is the lean phone-first tracker built for one job. If you're a homeowner tracking your own renovation, Home Stories is the only one of the three that fits the way you actually work on-site."
 keyword: "homezada vs houzz pro"
+cover: "/stock/14.png"
+coverAlt: "A tradesman fitting a white tiled backsplash above a kitchen worktop"
 publishDate: 2026-07-06
 author: "Robert Jensen"
 tags: ["comparison", "apps", "planning", "tools"]

--- a/src/content/blog/how-to-budget-a-home-renovation.md
+++ b/src/content/blog/how-to-budget-a-home-renovation.md
@@ -3,6 +3,8 @@ title: "How to Budget a Home Renovation Without Going Over (2026)"
 description: "How to budget a home renovation without going over: a step-by-step 2026 method using real quotes, the right contingency, and tracking that survives the build."
 lede: "To budget a home renovation without going over, build it from itemised quotes (not a single lump sum), add a 15–25% contingency, and track actual vs. estimated per line item from day one. The overrun almost always comes from costs nobody listed, not from prices that rose."
 keyword: "how to budget a home renovation"
+cover: "/stock/09.png"
+coverAlt: "Floor plans on a desk with a calculator, tape measure, notebook and pen"
 publishDate: 2026-06-01
 author: "Robert Jensen"
 tags: ["budgeting", "planning", "how-to"]

--- a/src/content/blog/how-to-organize-renovation-receipts.md
+++ b/src/content/blog/how-to-organize-renovation-receipts.md
@@ -3,6 +3,8 @@ title: "How to Organize Renovation Receipts for Tax & Insurance"
 description: "A shoebox of faded receipts costs you money at tax time and at claim time. Here's a capture-once system that keeps every renovation cost provable for years."
 lede: "Your renovation receipts are worth real money — but only if you can still find them, read them, and prove what they were for, years after the dust settles. Capital improvements can reduce the tax you owe when you sell, and an insurance claim is only ever as good as the evidence behind it. This is a practical, capture-once system for keeping every cost provable long after the project ends."
 keyword: "how to organize renovation receipts"
+cover: "/stock/03.webp"
+coverAlt: "A man at a kitchen table reading a paper receipt, more receipts and a phone spread in front of him"
 publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["budgeting", "organization", "tax", "insurance"]

--- a/src/content/blog/how-to-plan-a-home-renovation-step-by-step.md
+++ b/src/content/blog/how-to-plan-a-home-renovation-step-by-step.md
@@ -3,6 +3,8 @@ title: "How to Plan a Home Renovation Step by Step (2026 Guide)"
 description: "Step-by-step guide to planning a home renovation in 2026 — from the first decision to the final walkthrough. Real numbers, real timelines."
 lede: "Planning a home renovation doesn't have to mean spreadsheets, anxiety, and surprises that blow your budget. The right approach breaks the entire process into discrete, manageable steps — each with a clear start, a clear deliverable, and a clear next step. This guide walks you through every phase of a home renovation, from the very first decision to the final walkthrough, with realistic timelines and costs so you know exactly what comes next."
 keyword: "how to plan a home renovation step by step"
+cover: "/stock/13.png"
+coverAlt: "Two hands tracing a line across architectural drawings spread over a table"
 publishDate: 2026-07-14
 author: "Robert Jensen"
 tags: ["planning", "step-by-step", "first-timer", "guide"]

--- a/src/content/blog/how-to-track-home-improvement-expenses.md
+++ b/src/content/blog/how-to-track-home-improvement-expenses.md
@@ -3,6 +3,8 @@ title: "How to Track Home Improvement Expenses (4 Methods Compared)"
 description: "Four methods to track home improvement expenses — spreadsheet, Notion, a dedicated app, and receipts-in-a-jar — compared on what actually works on-site."
 lede: "Tracking home improvement expenses only matters if you're doing it on-site, where the money actually leaks. This post compares four methods on the single metric that matters: will you still be logging after three weeks of dust, decision fatigue, and contractor delays?"
 keyword: "how to track home improvement expenses"
+cover: "/stock/05.webp"
+coverAlt: "A homeowner and a contractor in a hard hat looking at a phone together on site"
 publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["budgeting", "planning", "how-to"]

--- a/src/content/blog/kitchen-renovation-timeline.md
+++ b/src/content/blog/kitchen-renovation-timeline.md
@@ -3,6 +3,8 @@ title: "A Realistic Kitchen Renovation Timeline (Week-by-Week)"
 description: "A realistic kitchen renovation timeline — week by week, from design to the final walkthrough — with real durations and hidden steps."
 lede: "Most kitchen renovation timelines are optimistic by 30–40%. They assume everything arrives on time, inspections pass first try, and your contractor has no other jobs bleeding into yours. This timeline shows what actually happens on a real kitchen renovation in 2026 — the weeks you plan for and the ones you don't."
 keyword: "renovation project timeline example"
+cover: "/stock/06.png"
+coverAlt: "A kitchen with new white cabinets and stone worktops fitted, the floor still unfinished"
 publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["kitchen", "planning", "timeline", "how-to"]

--- a/src/content/blog/notion-for-home-renovation.md
+++ b/src/content/blog/notion-for-home-renovation.md
@@ -3,6 +3,8 @@ title: "Notion vs Home Stories for Renovation Planning"
 description: "Notion is a brilliant renovation planning tool and a frustrating on-site one. Here's exactly where each fits — and why most people end up needing both."
 lede: "Notion is genuinely excellent for the planning half of a renovation: research, mood boards, contractor notes, a flexible database you can shape however you think. It's just as genuinely frustrating for the execution half — logging a receipt one-handed in a dusty kitchen — because it was never built for a phone on a building site. This is an honest map of where each tool wins."
 keyword: "notion for home renovation"
+cover: "/stock/12.png"
+coverAlt: "Power tools, tape measures and a hammer laid out across a worn workbench"
 publishDate: 2026-06-29
 author: "Robert Jensen"
 tags: ["planning", "tools", "comparison"]

--- a/src/content/blog/renovation-budget-template.md
+++ b/src/content/blog/renovation-budget-template.md
@@ -3,6 +3,8 @@ title: "Renovation Budget Template (Free PDF + Google Sheet)"
 description: "A simple renovation budget template that actually works — line-item, contingency-aware, and proven on real projects. Free PDF and Google Sheet."
 lede: "Most renovation budgets fail in the same three ways: missing line items, no contingency, and a spreadsheet that nobody opens after week two. This template fixes all three — and it's free."
 keyword: "renovation budget template"
+cover: "/stock/01.webp"
+coverAlt: "A couple standing in a stripped room, looking at a tablet together, paint swatches taped to the wall"
 publishDate: 2026-05-18
 author: "Robert Jensen"
 tags: ["budgeting", "templates", "planning"]

--- a/src/content/blog/renovation-checklist-printable.md
+++ b/src/content/blog/renovation-checklist-printable.md
@@ -3,6 +3,8 @@ title: "Printable Renovation Checklist: Every Task by Room"
 description: "A free printable renovation checklist organised room by room — every task from planning to handover, so nothing slips through the cracks."
 lede: "A renovation isn't one big job; it's a few hundred small ones, and the ones that get forgotten are always the cheap, boring tasks that turn expensive later. This printable checklist lists every task, grouped by room and by phase, so you can tick your way through a renovation without anything slipping through the cracks."
 keyword: "renovation checklist printable"
+cover: "/stock/11.png"
+coverAlt: "An empty room freshly painted white, with a paint tray and roller left on the floor"
 publishDate: 2026-06-15
 author: "Robert Jensen"
 tags: ["planning", "checklists", "templates"]

--- a/src/content/blog/renovation-contingency-budget.md
+++ b/src/content/blog/renovation-contingency-budget.md
@@ -3,6 +3,8 @@ title: "Renovation Contingency Budget: How Much to Set Aside"
 description: "How big a renovation contingency budget you really need, what it's for, when to dip in, and how to track it so surprises don't sink the project."
 lede: "A renovation contingency budget isn't padding or pessimism — it's a funded line item for the surprises you can't see yet. Size it to the home (15–25%, not the builder's-folklore 10%), ring-fence it so it isn't spent on upgrades by week three, and draw it down visibly so you always know how much runway is left."
 keyword: "renovation contingency budget"
+cover: "/stock/07.png"
+coverAlt: "A gutted bathroom with patched, pockmarked walls and a basin balanced on a timber trestle"
 publishDate: 2026-06-22
 author: "Robert Jensen"
 tags: ["budgeting", "planning", "how-to"]

--- a/src/content/blog/renovation-cost-overrun-statistics.md
+++ b/src/content/blog/renovation-cost-overrun-statistics.md
@@ -3,6 +3,8 @@ title: "Renovation Cost Overrun Statistics: What the Data Actually Says"
 description: "We analyzed 200 renovation projects: average cost overrun is 15–30%. Here's the data on why it happens and how to protect your budget."
 lede: "Renovations regularly go 15–30% over budget, and the data shows it's not a bug — it's a structural feature of how renovations are planned. The overrun isn't randomness; it's the gap between optimistic pre-project estimates and the inevitable surprises that surface once the walls open. Size your contingency to the evidence, not the folklore."
 keyword: "renovation cost overrun statistics"
+cover: "/stock/10.png"
+coverAlt: "A close-up of a renovator's hand resting on stripped, unfinished floorboards in a sunlit room"
 publishDate: 2026-07-13
 author: "Robert Jensen"
 tags: ["budgeting", "statistics", "planning"]

--- a/src/content/blog/renovation-spreadsheet-alternative.md
+++ b/src/content/blog/renovation-spreadsheet-alternative.md
@@ -3,6 +3,8 @@ title: "Why a Spreadsheet Stops Working Halfway Through Your Renovation"
 description: "Spreadsheets are great for planning a renovation and terrible for surviving one. Here's exactly where they fail — and what to replace them with."
 lede: "Every renovator starts with a spreadsheet. Most abandon it by week three. The reasons are predictable, repeatable, and not about the spreadsheet — they're about renovation reality."
 keyword: "renovation spreadsheet alternative"
+cover: "/stock/04.webp"
+coverAlt: "A man photographing a half-painted wall with his phone to document the progress"
 publishDate: 2026-05-25
 author: "Robert Jensen"
 tags: ["planning", "tools", "comparison"]

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,6 +7,10 @@ const blog = defineCollection({
     description: z.string().max(160),
     lede: z.string(),
     keyword: z.string(),
+    // Card image for the blog overview. alt describes the photograph itself —
+    // it is content, not decoration, so it gets read out.
+    cover: z.string().optional(),
+    coverAlt: z.string().optional(),
     publishDate: z.coerce.date(),
     updatedDate: z.coerce.date().optional(),
     author: z.string().default("Robert Jensen"),

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -29,14 +29,15 @@ const formatDate = (d: Date) =>
   hideAppBanner={true}
 >
   <main class="max-w-screen-lg mx-auto px-4 py-12 md:py-20">
-    <header class="mb-12 max-w-3xl">
-      <p class="mb-3 text-sm font-semibold uppercase tracking-wide text-primary">
+    <header class="mb-14 max-w-3xl">
+      <p class="tick-label m-0 flex items-center gap-3 text-base-content/50">
+        <span class="inline-block h-0.5 w-8 bg-accent"></span>
         Home Stories Blog
       </p>
-      <h1 class="mb-4 text-4xl font-bold leading-tight md:text-5xl">
+      <h1 class="mb-4 mt-5 font-display text-4xl font-extrabold leading-[1.05] tracking-tightest md:text-5xl">
         Plan, budget, and survive your renovation.
       </h1>
-      <p class="text-lg text-base-content/80 md:text-xl">
+      <p class="text-lg leading-relaxed text-base-content/70">
         Practical guides for homeowners who'd rather track a renovation in
         something better than a spreadsheet. Real numbers, real templates, no
         fluff.
@@ -47,32 +48,47 @@ const formatDate = (d: Date) =>
       postsWithMeta.length === 0 ? (
         <p class="text-base-content/60">No posts yet — coming soon.</p>
       ) : (
-        <ul class="grid gap-8 md:grid-cols-2">
-          {postsWithMeta.map(({ post, minutes }) => (
-            <li class="group rounded-2xl border border-base-300 bg-base-100 p-6 transition hover:border-primary hover:shadow-lg sm:p-8">
-              <a href={`/blog/${post.slug}/`} class="block">
-                <div class="mb-3 flex flex-wrap items-center gap-2 text-xs text-base-content/60">
-                  <time datetime={post.data.publishDate.toISOString()}>
-                    {formatDate(post.data.publishDate)}
-                  </time>
-                  <span aria-hidden="true">•</span>
-                  <span>{minutes} min read</span>
-                  {post.data.tags.slice(0, 2).map((tag) => (
-                    <>
-                      <span aria-hidden="true">•</span>
-                      <span class="rounded-full bg-base-200 px-2 py-0.5">
-                        {tag}
-                      </span>
-                    </>
-                  ))}
+        <ul class="grid list-none gap-8 p-0 md:grid-cols-2">
+          {postsWithMeta.map(({ post, minutes }, index) => (
+            <li class="group m-0 overflow-hidden rounded-box border border-base-300 bg-base-100 p-0 transition-colors hover:border-base-content/30">
+              <a href={`/blog/${post.slug}/`} class="flex h-full flex-col">
+                {post.data.cover && (
+                  <div class="overflow-hidden border-b border-base-300 bg-base-200">
+                    <img
+                      src={post.data.cover}
+                      alt={post.data.coverAlt ?? ""}
+                      width={640}
+                      height={360}
+                      loading={index < 2 ? "eager" : "lazy"}
+                      decoding="async"
+                      class="aspect-[16/9] w-full object-cover transition-transform duration-500 ease-out group-hover:scale-[1.03]"
+                    />
+                  </div>
+                )}
+                <div class="flex flex-1 flex-col p-6 sm:p-7">
+                  <div class="tick-label flex flex-wrap items-center gap-x-2 gap-y-1 text-base-content/40">
+                    <time datetime={post.data.publishDate.toISOString()}>
+                      {formatDate(post.data.publishDate)}
+                    </time>
+                    <span aria-hidden="true">·</span>
+                    <span>{minutes} min</span>
+                    {post.data.tags.slice(0, 2).map((tag) => (
+                      <>
+                        <span aria-hidden="true">·</span>
+                        <span>{tag}</span>
+                      </>
+                    ))}
+                  </div>
+                  <h2 class="mb-0 mt-3 font-display text-xl font-bold leading-snug tracking-tight text-base-content transition-colors group-hover:text-primary sm:text-2xl">
+                    {post.data.title}
+                  </h2>
+                  <p class="mt-3 text-base leading-relaxed text-base-content/70">
+                    {post.data.description}
+                  </p>
+                  <span class="tick-label mt-5 inline-block self-start border-b-2 border-accent pb-1 text-base-content">
+                    Read more
+                  </span>
                 </div>
-                <h2 class="mb-3 text-xl font-bold leading-snug text-base-content group-hover:text-primary sm:text-2xl">
-                  {post.data.title}
-                </h2>
-                <p class="text-base text-base-content/80">{post.data.description}</p>
-                <p class="mt-4 text-sm font-semibold text-primary">
-                  Read more →
-                </p>
               </a>
             </li>
           ))}


### PR DESCRIPTION
Closes #60

The `/blog/` overview rendered 14 text-only cards — flat, and hard to scan.

## Approach

Every post already contained ComfyUI renovation photos in its body, so **covers are promoted from real assets** rather than bolted on from unrelated stock.

Each post gets a **distinct** image, matched to what the photograph actually shows:

| post | cover |
|---|---|
| how-to-budget-a-home-renovation | floor plans, calculator, tape measure |
| renovation-contingency-budget | a gutted bathroom, walls pockmarked with patches |
| how-to-organize-renovation-receipts | receipts spread across a kitchen table |
| home-renovation-phases | a room stripped back to studs and joists |
| how-to-plan-a-home-renovation-step-by-step | hands tracing architectural drawings |
| … | (14 in total, all distinct) |

This mattered: **three posts previously shared `09.png` and two had no image at all** — duplicate covers side by side on a grid read as broken.

## Details

- `cover` + `coverAlt` added to the content collection schema
- **Alt text describes the photograph.** These are content, not decoration, so they are read out rather than skipped
- Covers render on the overview and in the "Keep reading" related-posts strip
- Cards restyled to the site's measured direction (mono meta line, display titles, tape-yellow "Read more" rule)
- First two images load eagerly, the rest lazily; explicit `width`/`height` to avoid layout shift

## Verification

`astro check` clean, build green. Checked in-browser: 14 covers on the page, **all distinct, none missing alt text**, and the grid stacks correctly on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TSizUb4R19kYB24qrb4dx