### PR TITLE
Fix OG image + remove self-serving review schema (#62)

### DIFF
--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -6,12 +6,24 @@ const { backgroundGrid, seo, logo, theme, forceTheme, appStoreLink, name, appSto
   Astro.props as TemplateConfig & { noindex?: boolean };
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
-const ogImage = logo.startsWith("http") ? logo : new URL("/og-image.png", Astro.site).href;
+// Always a real 1200x630 image (generated in src/pages/og-image.png.ts) so social
+// shares are not the square App Store icon cropped into a landscape frame.
+const ogImage = new URL("/og-image.png", Astro.site).href;
 const siteUrl = Astro.site?.href ?? "https://home-stories.12f.dk";
 
-// Dynamic rating data from App Store (with sensible fallbacks)
-const ratingValue = appStore?.rating && appStore.rating > 0 ? appStore.rating.toFixed(1) : "5.0";
-const ratingCount = appStore?.ratingCount && appStore.ratingCount > 0 ? String(appStore.ratingCount) : "1";
+// Only expose rating markup when the App Store actually reports real ratings.
+// A fabricated aggregateRating (e.g. 5.0 / count 1) is self-serving review markup
+// and can trigger a Google structured-data manual action.
+const hasRealRatings = !!(appStore?.ratingCount && appStore.ratingCount > 0 && appStore?.rating && appStore.rating > 0);
+const aggregateRating = hasRealRatings
+  ? {
+      "@type": "AggregateRating",
+      "ratingValue": appStore!.rating.toFixed(1),
+      "ratingCount": String(appStore!.ratingCount),
+      "bestRating": "5",
+      "worstRating": "1",
+    }
+  : undefined;
 ---
 
 <!doctype html>
@@ -103,13 +115,7 @@ const ratingCount = appStore?.ratingCount && appStore.ratingCount > 0 ? String(a
         "priceCurrency": "USD",
         "availability": "https://schema.org/InStock"
       },
-      "aggregateRating": {
-        "@type": "AggregateRating",
-        "ratingValue": ratingValue,
-        "ratingCount": ratingCount,
-        "bestRating": "5",
-        "worstRating": "1"
-      },
+      ...(aggregateRating ? { "aggregateRating": aggregateRating } : {}),
       "description": seo.description,
       "url": canonicalURL.href,
       "downloadUrl": appStoreLink,
@@ -130,27 +136,7 @@ const ratingCount = appStore?.ratingCount && appStore.ratingCount > 0 ? String(a
         "name": "Robert Jensen",
         "email": "robert@12f.dk",
         "url": "https://www.12f.dk"
-      },
-      "review": [
-        {
-          "@type": "Review",
-          "reviewBody": "Home Stories made our kitchen renovation so much easier to manage. The budget tracking feature showed exactly where every krone went, and the photo timeline became a fantastic record of the transformation.",
-          "author": { "@type": "Person", "name": "Anders T." },
-          "reviewRating": { "@type": "Rating", "ratingValue": "5", "bestRating": "5" }
-        },
-        {
-          "@type": "Review",
-          "reviewBody": "I'm renovating multiple rooms and Home Stories keeps everything organized. Each project has its own tasks, budget, and photos. The PDF export is perfect for sharing progress with contractors.",
-          "author": { "@type": "Person", "name": "Maria S." },
-          "reviewRating": { "@type": "Rating", "ratingValue": "5", "bestRating": "5" }
-        },
-        {
-          "@type": "Review",
-          "reviewBody": "The budget charts are incredible. I can see at a glance what's spent, what's remaining, and potential costs. No more spreadsheets - Home Stories has everything in one place.",
-          "author": { "@type": "Person", "name": "Thomas H." },
-          "reviewRating": { "@type": "Rating", "ratingValue": "5", "bestRating": "5" }
-        }
-      ]
+      }
     })} />
 
     <!-- Structured Data - FAQ -->

--- a/src/pages/og-image.png.ts
+++ b/src/pages/og-image.png.ts
@@ -1,0 +1,127 @@
+import type { APIContext } from "astro";
+import satori from "satori";
+import { Resvg } from "@resvg/resvg-js";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const interBold = await readFile(
+  path.join(process.cwd(), "src/assets/Inter-Bold.ttf"),
+);
+const interRegular = await readFile(
+  path.join(process.cwd(), "src/assets/Inter-Regular.ttf"),
+);
+
+// Static 1200x630 Open Graph image for the homepage / social shares.
+export async function GET(_context: APIContext) {
+  const svg = await satori(
+    {
+      type: "div",
+      props: {
+        style: {
+          width: "1200px",
+          height: "630px",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "70px 80px",
+          background: "linear-gradient(135deg, #007AFF 0%, #0055AA 100%)",
+          color: "white",
+          fontFamily: "Inter",
+        },
+        children: [
+          {
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                alignItems: "center",
+                gap: "16px",
+                fontSize: "28px",
+                fontWeight: 700,
+                letterSpacing: "-0.5px",
+                opacity: 0.95,
+              },
+              children: [
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      width: "48px",
+                      height: "48px",
+                      borderRadius: "12px",
+                      background: "white",
+                      color: "#007AFF",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                      fontSize: "30px",
+                      fontWeight: 700,
+                    },
+                    children: "H",
+                  },
+                },
+                "Home Stories",
+              ],
+            },
+          },
+          {
+            type: "div",
+            props: {
+              style: {
+                display: "flex",
+                flexDirection: "column",
+                gap: "20px",
+              },
+              children: [
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      fontSize: "72px",
+                      fontWeight: 700,
+                      lineHeight: 1.1,
+                      letterSpacing: "-2px",
+                      maxWidth: "1040px",
+                    },
+                    children: "Your home renovation, measured.",
+                  },
+                },
+                {
+                  type: "div",
+                  props: {
+                    style: {
+                      fontSize: "30px",
+                      fontWeight: 400,
+                      opacity: 0.9,
+                      letterSpacing: "-0.3px",
+                    },
+                    children: "Free renovation tracker for iPhone · home-stories.12f.dk",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as any,
+    {
+      width: 1200,
+      height: 630,
+      fonts: [
+        { name: "Inter", data: interBold, weight: 700, style: "normal" },
+        { name: "Inter", data: interRegular, weight: 400, style: "normal" },
+      ],
+    },
+  );
+
+  const png = new Resvg(svg, { fitTo: { mode: "width", value: 1200 } })
+    .render()
+    .asPng();
+
+  return new Response(png, {
+    headers: {
+      "Content-Type": "image/png",
+      "Cache-Control": "public, max-age=31536000, immutable",
+    },
+  });
+}


### PR DESCRIPTION
Closes #62.

## What changed
**1. OG image (bug fix)**
- `og:image` / `twitter:image` previously pointed at the square **512×512 App Store icon** while declaring `og:image:width/height` = 1200×630. Social shares (iMessage, LinkedIn, Facebook, Slack) cropped it into a broken landscape frame, and the `/og-image.png` fallback didn't exist.
- Added `src/pages/og-image.png.ts` — a real **1200×630** homepage OG image rendered with the existing satori/resvg setup (same infra as the blog OG route). `og:image` now points to it.

**2. Self-serving review schema (Google risk)**
- `aggregateRating` is now emitted **only when the App Store reports real ratings** (falls back to omission instead of a fabricated `5.0 / count 1`).
- Removed the hardcoded `review[]` array of invented 5-star reviewers (Anders T. / Maria S. / Thomas H.). Fabricated review markup is self-serving and can trigger a structured-data manual action.
- Note: the app currently has 1 genuine 5-star rating, so `aggregateRating` still renders — but now from **live data**, and it disappears cleanly if ratings drop to zero.

## Not included (see #62 item 3)
Localization / hreflang is a content project (translated pages), not a meta-tag fix — tracked separately.

## Verification
- `pnpm build` passes; `/og-image.png` builds as `PNG 1200×630`.
- Built `index.html`: `og:image` → `/og-image.png`, no fabricated `review[]`, `aggregateRating` reflects live iTunes data (5.0 / 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)