### PR TITLE
Surface missing app features + align SEO

### DIFF
--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -54,7 +54,7 @@ const aggregateRating = hasRealRatings
     <title>{seo.title}</title>
     <meta name="title" content={seo.title} />
     <meta name="description" content={seo.description} />
-    <meta name="keywords" content="home renovation app, renovation tracker, home improvement app, project management, budget tracking, renovation budget, home project planner, renovation photos, before after renovation, iOS renovation app, iPhone home app, renovation journal, home remodel tracker, renovation progress, DIY project tracker, home renovation planner, renovation cost tracker, home improvement tracker, renovation organizer, free renovation app" />
+    <meta name="keywords" content="home renovation app, renovation tracker, home improvement app, project management, budget tracking, renovation budget, home project planner, renovation photos, before after renovation, iOS renovation app, iPhone home app, renovation journal, home remodel tracker, renovation progress, DIY project tracker, home renovation planner, renovation cost tracker, home improvement tracker, renovation organizer, free renovation app, renovation budget widget, renovation lock screen widget, renovation time tracking, renovation shopping list, renovation receipts app, iCloud renovation sync, share renovation project, renovation collaboration app, renovation notes app, renovation project priorities" />
     <meta name="author" content="Robert Jensen" />
     <meta
       name="robots"
@@ -126,7 +126,7 @@ const aggregateRating = hasRealRatings
         new URL("/screenshots/tasks.webp", Astro.site).href
       ],
       "image": logo.startsWith("http") ? logo : new URL(logo, Astro.site).href,
-      "featureList": "Budget Tracking, Photo Timeline, Task Management, PDF Export, Offline Support, iCloud Sync",
+      "featureList": "Budget Tracking, Photo Timeline, Task Management, PDF Export, Offline Support, iCloud Sync, Real-time Project Sharing, Home Screen & Lock Screen Widgets, Live Activities, Time Tracking, Notes & Document Storage, Item & Shopping List Tracking, Search & Share Extension, Project Priorities, 51 Languages, VoiceOver Accessibility",
       "softwareVersion": appStore?.version ?? "1.0.0",
       "datePublished": appStore?.lastUpdated ?? undefined,
       "inLanguage": "en",
@@ -182,6 +182,30 @@ const aggregateRating = hasRealRatings
           "acceptedAnswer": {
             "@type": "Answer",
             "text": "Home Stories is currently available for iPhone and requires iOS 17.0 or later. We're focused on delivering the best possible experience on iOS first."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does Home Stories have widgets?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Add a budget progress ring and upcoming tasks to your Home Screen and Lock Screen, and use Live Activities with Dynamic Island to keep a project timer in view while you work — all without opening the app."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can I collaborate with a partner or contractor?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Share a project over iCloud and it stays in sync in real time across everyone's devices, so a partner, family member, or contractor can follow the budget, tasks, and photos as they change."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What languages is Home Stories available in?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Home Stories is fully translated into 51 languages, including English, German, French, Spanish, Italian, Danish, Dutch, Portuguese, Japanese, Chinese, Korean, and many more, with full VoiceOver and Dynamic Type accessibility support."
           }
         }
       ]

--- a/src/modules/home/_components/capabilities/index.tsx
+++ b/src/modules/home/_components/capabilities/index.tsx
@@ -1,0 +1,120 @@
+import { motion } from "framer-motion";
+import { useContext, type ReactNode } from "react";
+import { ConfigContext } from "../../../../utils/configContext";
+import SectionHeading from "../../../../components/sectionHeading";
+
+// Inline, stroke-based icons keyed by the `icon` field in config. Kept here so
+// adding a capability needs no new image asset — just a key that exists below.
+const icons: Record<string, ReactNode> = {
+  widget: (
+    <>
+      <rect x="3" y="3" width="7" height="7" rx="1.5" />
+      <rect x="14" y="3" width="7" height="7" rx="1.5" />
+      <rect x="3" y="14" width="7" height="7" rx="1.5" />
+      <circle cx="17.5" cy="17.5" r="3.5" />
+    </>
+  ),
+  clock: (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </>
+  ),
+  note: (
+    <>
+      <path d="M5 3h9l5 5v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1Z" />
+      <path d="M14 3v5h5" />
+      <path d="M8 13h8M8 17h5" />
+    </>
+  ),
+  tag: (
+    <>
+      <path d="M3 12V4a1 1 0 0 1 1-1h8l9 9-9 9-9-9Z" />
+      <circle cx="7.5" cy="7.5" r="1.5" />
+    </>
+  ),
+  search: (
+    <>
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </>
+  ),
+  users: (
+    <>
+      <circle cx="9" cy="8" r="3.5" />
+      <path d="M2.5 20a6.5 6.5 0 0 1 13 0" />
+      <path d="M16 5a3.5 3.5 0 0 1 0 7M22 20a6.5 6.5 0 0 0-5-6.3" />
+    </>
+  ),
+  flag: (
+    <>
+      <path d="M5 21V4M5 4h11l-2 4 2 4H5" />
+    </>
+  ),
+  globe: (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M3 12h18M12 3c2.5 2.5 3.8 5.7 3.8 9S14.5 18.5 12 21C9.5 18.5 8.2 15.3 8.2 12S9.5 5.5 12 3Z" />
+    </>
+  ),
+};
+
+function Capabilities() {
+  const {
+    home: { capabilities },
+  } = useContext(ConfigContext)!;
+  if (!capabilities) return null;
+
+  return (
+    <section
+      id={capabilities.id}
+      className="mx-auto max-w-screen-lg px-4 pb-20 md:pb-28"
+    >
+      <SectionHeading
+        label="More"
+        title={capabilities.title}
+        subtitle={capabilities.subtitle}
+      />
+
+      <div className="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {capabilities.cards.map((cap, index) => (
+          <motion.article
+            key={cap.title}
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-60px" }}
+            transition={{
+              duration: 0.5,
+              delay: (index % 4) * 0.06,
+              ease: [0.16, 1, 0.3, 1],
+            }}
+            className="flex flex-col rounded-box border border-base-300 bg-base-100 p-6"
+          >
+            <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                {icons[cap.icon] ?? icons.widget}
+              </svg>
+            </span>
+            <h3 className="mt-4 font-display text-lg font-bold tracking-tight text-base-content">
+              {cap.title}
+            </h3>
+            <p className="mt-2 text-sm text-base-content/70">{cap.subtitle}</p>
+          </motion.article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default Capabilities;

--- a/src/modules/home/index.tsx
+++ b/src/modules/home/index.tsx
@@ -7,6 +7,7 @@ import type { TemplateConfig } from "../../utils/configType";
 import Header from "./_components/header";
 import Facts from "./_components/facts";
 import Features from "./_components/features";
+import Capabilities from "./_components/capabilities";
 import Faq from "./_components/faq";
 import HowItWorks from "./_components/howItWorks";
 import Testimonials from "./_components/testimonials";
@@ -28,6 +29,7 @@ function Home({ config, posts = [] }: Props) {
           <Header />
           <Facts />
           <Features />
+          <Capabilities />
           <VideoDemo />
           <HowItWorks />
           <Testimonials />

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -170,6 +170,62 @@ const templateConfig: TemplateConfig = {
         },
       ],
     },
+    capabilities: {
+      id: "more",
+      title: "And everything around the edges",
+      subtitle:
+        "The four screens do the heavy lifting. These are the parts that keep the rest of a renovation from slipping through the cracks.",
+      cards: [
+        {
+          icon: "widget",
+          title: "Widgets & Live Activities",
+          subtitle:
+            "A budget ring on your Lock Screen, the next tasks at a glance, and a Dynamic Island timer while you work — without opening the app.",
+        },
+        {
+          icon: "clock",
+          title: "Time tracking",
+          subtitle:
+            "Log hours against a project and see where the days actually went, broken down visually alongside the money.",
+        },
+        {
+          icon: "note",
+          title: "Notes & documents",
+          subtitle:
+            "Keep contracts, receipts, and tagged notes with photos attached to the project they belong to — not in a drawer.",
+        },
+        {
+          icon: "tag",
+          title: "Items & shopping lists",
+          subtitle:
+            "Save purchases with prices and store details, organised by phase, so actual cost lands next to what you estimated.",
+        },
+        {
+          icon: "search",
+          title: "Search & Share extension",
+          subtitle:
+            "Search across every project instantly, and save a product straight from Safari, IKEA, or Amazon into the right one.",
+        },
+        {
+          icon: "users",
+          title: "Real-time collaboration",
+          subtitle:
+            "Share a project over iCloud and keep it in sync with a partner, family, or the contractor doing the work.",
+        },
+        {
+          icon: "flag",
+          title: "Project priorities",
+          subtitle:
+            "Flag each project Low, Medium, or High and sort your list — by priority, date, or name — so the next job is on top.",
+        },
+        {
+          icon: "globe",
+          title: "51 languages, accessible",
+          subtitle:
+            "Fully translated into 51 languages, with VoiceOver and Dynamic Type support throughout. Works 100% offline.",
+        },
+      ],
+    },
     faq: {
       id: "faq",
       title: "Questions, answered",
@@ -198,6 +254,21 @@ const templateConfig: TemplateConfig = {
           question: "What devices are supported?",
           answer:
             "Home Stories is currently available for iPhone and requires iOS 17.0 or later. We're focused on delivering the best possible experience on iOS first.",
+        },
+        {
+          question: "Does Home Stories have widgets?",
+          answer:
+            "Yes. Add a budget progress ring and upcoming tasks to your Home Screen and Lock Screen, and use Live Activities with Dynamic Island to keep a project timer in view while you work — all without opening the app.",
+        },
+        {
+          question: "Can I collaborate with a partner or contractor?",
+          answer:
+            "Yes. Share a project over iCloud and it stays in sync in real time across everyone's devices, so a partner, family member, or contractor can follow the budget, tasks, and photos as they change.",
+        },
+        {
+          question: "What languages is Home Stories available in?",
+          answer:
+            "Home Stories is fully translated into 51 languages, including English, German, French, Spanish, Italian, Danish, Dutch, Portuguese, Japanese, Chinese, Korean, and many more, with full VoiceOver and Dynamic Type accessibility support.",
         },
       ],
     },

--- a/src/utils/configType.ts
+++ b/src/utils/configType.ts
@@ -140,5 +140,17 @@ export type TemplateConfig = {
                 subtitle: string;
             }[];
         } | undefined;
+        /** Secondary grid of everything the flagship four screens don't cover.
+         *  Icon is a key into the inline SVG set in the capabilities component. */
+        capabilities?: {
+            id?: string | undefined;
+            title: string;
+            subtitle?: string | undefined;
+            cards: {
+                icon: string;
+                title: string;
+                subtitle: string;
+            }[];
+        } | undefined;
     };
 }


### PR DESCRIPTION
## Why
The App Store description lists a lot the app does that never appeared on the landing page. This adds those features to the site and updates SEO to match.

Closes #65, closes #66.

## Features (#65)
New **"And everything around the edges"** grid below the flagship four-screen section — icon cards for:
- Widgets & Live Activities (Lock Screen budget ring, Dynamic Island timer)
- Time tracking
- Notes & documents
- Items & shopping lists
- Search & Share extension (save from Safari / IKEA / Amazon)
- Real-time collaboration (iCloud sharing)
- Project priorities (new in v1.9.4)
- 51 languages + accessibility

The flagship "Four screens do the work" section is unchanged. Three matching FAQ entries added (widgets, collaboration, languages).

## SEO (#66)
- Expanded `SoftwareApplication.featureList` structured data
- Added the 3 new FAQs to the `FAQPage` schema
- Extended `keywords` meta (renovation widget, iCloud renovation sync, renovation collaboration, shopping list, …)

## Notes
- Icons are inline SVG (no new image assets), keyed from config so adding a card needs no asset.
- `pnpm build` passes; section verified in-browser (all 8 cards + icons render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CS934gML7VT1aoSwpC7TdG