### PR TITLE
Add CI build gate, deploy-failure alert & branch protection (closes #73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+# Build gate: run the exact production build on every PR into main, so a
+# content-schema violation (e.g. an over-length title) fails the PR instead of
+# landing on main and silently freezing the Pages deploy. See issue #73.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build site (validates content schema)
+        run: pnpm build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
 
 concurrency:
   group: pages
@@ -53,3 +54,38 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  # A failed production deploy used to be silent — on 2026-07-15 the site sat
+  # stale for ~8h with no signal. This job opens (or updates) a tracking issue
+  # whenever build/deploy fails, so the failure is visible and actionable. #73
+  notify-failure:
+    needs: [build, deploy]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update a deploy-failure issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = '🚨 Production deploy is failing';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.sha.slice(0, 7);
+            const body = [
+              `The **Deploy to GitHub Pages** workflow failed on \`${sha}\` (\`${context.ref}\`).`,
+              ``,
+              `Failed run: ${runUrl}`,
+              ``,
+              `Production is stale until this is fixed. Opened automatically by the deploy workflow (see #73).`,
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+            const hit = existing.find(i => i.title === title && !i.pull_request);
+            if (hit) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: hit.number, body });
+            } else {
+              await github.rest.issues.create({ owner, repo, title, body });
+            }


### PR DESCRIPTION
## What & why

The only workflow was **Deploy** (on push to `main`), with no PR gate and no branch protection. A build that fails the Astro content-schema check still lands on `main` and silently leaves production stale — the systemic cause of #71/#72 (9+ consecutive failed deploys on 2026-07-15). This PR adds the missing guard rails.

## Changes

1. **`ci.yml` — PR build gate.** Runs the exact production `pnpm build` on every PR into `main` (job **`verify`**). A schema violation (e.g. an over-length title) now fails the PR instead of `main`. Uses `--frozen-lockfile` so lockfile drift fails too.
2. **`deploy.yml` — failure alert.** A new `notify-failure` job opens (or updates) a tracking issue whenever build/deploy fails, so a broken deploy is visible and actionable instead of silent (added `issues: write`).
3. **Branch protection on `main`** — applied via the settings API: require the `verify` check to pass before merge, and block force-pushes/deletions (a force-push is the most likely cause of the #72 history divergence).

## Acceptance (from #73)
- ✅ A PR that violates the content schema shows a failing required check — the `verify` check on this very PR dogfoods it.
- ✅ Direct pushes / force-pushes to `main` are blocked (branch protection).
- ✅ A failed Deploy run produces a visible alert (auto-opened issue).

Closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAATT9vHuVXTyJNgNykPu6
