### PR TITLE
Gate AggregateRating on a credible rating count (closes #75)

### DIFF
--- a/src/Layout.astro
+++ b/src/Layout.astro
@@ -24,10 +24,14 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const ogImage = new URL("/og-image.png", Astro.site).href;
 const siteUrl = Astro.site?.href ?? "https://home-stories.12f.dk";
 
-// Only expose rating markup when the App Store actually reports real ratings.
-// A fabricated aggregateRating (e.g. 5.0 / count 1) is self-serving review markup
-// and can trigger a Google structured-data manual action.
-const hasRealRatings = !!(appStore?.ratingCount && appStore.ratingCount > 0 && appStore?.rating && appStore.rating > 0);
+// Only expose rating markup once the App Store reports a *credible sample* of
+// real ratings. The data is genuine, but a single 5.0 rating (count 1) is thin,
+// self-serving-looking review markup: Google won't grant a review rich result on
+// so few ratings and can treat it as a structured-data manual-action risk. Gate
+// on a minimum count so the markup appears automatically once the app has a
+// meaningful number of ratings, straight from the live App Store lookup. See #75.
+const MIN_RATING_COUNT = 5;
+const hasRealRatings = !!(appStore?.ratingCount && appStore.ratingCount >= MIN_RATING_COUNT && appStore?.rating && appStore.rating > 0);
 const aggregateRating = hasRealRatings
   ? {
       "@type": "AggregateRating",


### PR DESCRIPTION
## What & why

The homepage `SoftwareApplication` JSON-LD shipped an `AggregateRating` whenever the App Store reported `ratingCount > 0`. The data is real, but a **single 5.0 rating** is thin, self-serving-looking review markup — Google won't grant a review rich result on so few ratings and can treat it as a structured-data manual-action risk. (Separate from the `Review` blocks removed in #63.)

## Change

`src/Layout.astro`: gate the markup on `MIN_RATING_COUNT = 5`. No `AggregateRating` is emitted below the threshold; once the app has a meaningful number of real ratings the markup returns automatically from the live App Store lookup — no future code change needed.

## Verification

`pnpm build` green. In the built `dist/`:
- `"@type":"AggregateRating"` on homepage: **0** (was 1)
- `aggregateRating` in any JSON-LD block (homepage + localized): **none**
- `SoftwareApplication` schema otherwise intact ✅

The visible star-rating component (real App Store data) is intentionally left unchanged — #75 is about the structured-data markup.

Closes #75.

> Merge order: this depends on #81 (the CI gate). Once #81 is on `main`, the required `verify` check can run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAATT9vHuVXTyJNgNykPu6
