### PR TITLE
Enable legal links in the footer (closes #3, closes #40)

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -62,9 +62,9 @@ const templateConfig: TemplateConfig = {
   googlePlayLink: "",
   footer: {
     legalLinks: {
-      termsAndConditions: false,
-      cookiesPolicy: false,
-      privacyPolicy: false,
+      termsAndConditions: true,
+      cookiesPolicy: true,
+      privacyPolicy: true,
     },
     socials: {},
     links: [


### PR DESCRIPTION
Flips the three `footer.legalLinks` config flags to `true`. The footer component and all three legal pages already existed — verified in the built output that Privacy policy, Terms & conditions and Cookies policy now render in the footer.

Completes #40: the redesign already fixed layout/contact; legal links were the last missing piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAATT9vHuVXTyJNgNykPu6