### PR TITLE
Add a branded 404 page (closes #78)

### DIFF
--- a/src/modules/notFound/index.tsx
+++ b/src/modules/notFound/index.tsx
@@ -1,0 +1,54 @@
+import Navbar from "../../components/navbar";
+import Footer from "../../components/footer";
+import { ConfigContext } from "../../utils/configContext";
+import type { TemplateConfig } from "../../utils/configType";
+
+interface Props {
+  config: TemplateConfig;
+}
+
+/**
+ * Branded 404. Keeps the site chrome (navbar/footer) so a dead link is a
+ * detour, not a dead end — and points at the pages people usually wanted.
+ */
+function NotFound({ config }: Props) {
+  return (
+    <ConfigContext.Provider value={config}>
+      <Navbar />
+      <main className="flex min-h-[60vh] items-center px-4 py-24">
+        <div className="mx-auto w-full max-w-screen-lg">
+          <p className="tick-label m-0 flex items-center gap-3 text-base-content/50">
+            <span className="inline-block h-0.5 w-8 bg-accent" />
+            404 — PAGE NOT FOUND
+          </p>
+          <h1 className="mt-4 font-display text-4xl font-extrabold leading-[1.1] tracking-tightest md:text-6xl">
+            That wall isn't there anymore.
+          </h1>
+          <p className="mt-6 max-w-xl leading-relaxed text-base-content/70">
+            The page you're after was moved, renamed, or never built. The rest
+            of the site is still standing.
+          </p>
+          <div className="mt-10 flex flex-wrap items-center gap-6">
+            <a href="/" className="btn btn-primary">
+              Back to the homepage
+            </a>
+            <a href="/blog/" className="link text-base-content/70">
+              Read the blog
+            </a>
+            <a
+              href={config.appStoreLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link text-base-content/70"
+            >
+              Get the app
+            </a>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </ConfigContext.Provider>
+  );
+}
+
+export default NotFound;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,17 @@
+---
+import NotFound from "@modules/notFound";
+import Layout from "Layout.astro";
+import defaultTemplateConfig from "utils/config";
+
+// GitHub Pages serves dist/404.html for any unmatched path. Branded so a bad
+// link keeps the site chrome and routes people back in. Noindexed: error pages
+// have no business in the index. See #78.
+const seo = {
+  title: "Page not found — Home Stories",
+  description: "That page was moved, renamed, or never built.",
+};
+---
+
+<Layout {...defaultTemplateConfig} seo={seo} noindex>
+  <NotFound client:load config={defaultTemplateConfig} />
+</Layout>


### PR DESCRIPTION
Adds `src/pages/404.astro` + a small `notFound` module reusing the existing navbar/footer and section-heading conventions. Astro emits `dist/404.html`, which GitHub Pages serves automatically for unmatched paths. Noindexed. Build verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAATT9vHuVXTyJNgNykPu6